### PR TITLE
Improvements to Accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ This repository deploys two API endpoints:
 
 If the daily snapshots need to be rebuilt (e.g. change in the subgraph or the snapshot structure), simply delete the `snapshots` collection in the GCP project's Firestore section.
 
+This can alternatively be achieved using the `firebase` CLI:
+
+`firebase firestore:delete --recursive "/snapshots" -P <GCP PROJECT>`
+
 ### OpenAPI
 
 REST API clients can utilise the `openapi/openapi.yml` file to generate typings. The schema, contained in `openapi/snapshot.yaml` is regenerated with the `yarn codegen` command.

--- a/codegen.ts
+++ b/codegen.ts
@@ -2,7 +2,7 @@ import type { CodegenConfig } from "@graphql-codegen/cli";
 
 const config: CodegenConfig = {
   overwrite: true,
-  schema: "https://api.studio.thegraph.com/query/46563/cooler-loans/1.3.0",
+  schema: "https://api.studio.thegraph.com/query/46563/cooler-loans/1.3.1",
   documents: "./src/**/*.graphql",
   generates: {
     "src/generated/graphql.ts": {

--- a/codegen.ts
+++ b/codegen.ts
@@ -2,7 +2,7 @@ import type { CodegenConfig } from "@graphql-codegen/cli";
 
 const config: CodegenConfig = {
   overwrite: true,
-  schema: "https://api.studio.thegraph.com/query/46563/cooler-loans/1.2.0",
+  schema: "https://api.studio.thegraph.com/query/46563/cooler-loans/1.3.0",
   documents: "./src/**/*.graphql",
   generates: {
     "src/generated/graphql.ts": {

--- a/openapi/snapshot.yaml
+++ b/openapi/snapshot.yaml
@@ -84,43 +84,26 @@
         },
       "CoolerLoanOptional":
         {
-          "properties":
-            {
-              "borrower": { "type": "string" },
-              "collateral": { "type": "number" },
-              "collateralToken": { "type": "string" },
-              "cooler": { "type": "string" },
-              "createdBlock": { "type": "number" },
-              "createdTimestamp": { "type": "number" },
-              "createdTransaction": { "type": "string" },
-              "debtToken": { "type": "string" },
-              "expiryTimestamp": { "type": "number" },
-              "hasCallback": { "type": "boolean" },
-              "id": { "type": "string" },
-              "interest": { "type": "number" },
-              "lender": { "type": "string" },
-              "loanId": { "type": "number" },
-              "principal": { "type": "number" },
-            },
-          "required":
+          "allOf":
             [
-              "borrower",
-              "collateral",
-              "collateralToken",
-              "cooler",
-              "createdBlock",
-              "createdTimestamp",
-              "createdTransaction",
-              "debtToken",
-              "expiryTimestamp",
-              "hasCallback",
-              "id",
-              "interest",
-              "lender",
-              "loanId",
-              "principal",
+              {
+                "$ref": '#/definitions/Omit<CoolerLoan,"request"|"creationEvents"|"defaultedClaimEvents"|"extendEvents"|"repaymentEvents">',
+              },
+              {
+                "properties":
+                  {
+                    "request":
+                      {
+                        "properties":
+                          { "durationSeconds": { "type": "number" }, "interestPercentage": { "type": "number" } },
+                        "required": ["durationSeconds", "interestPercentage"],
+                        "type": "object",
+                      },
+                  },
+                "required": ["request"],
+                "type": "object",
+              },
             ],
-          "type": "object",
         },
       "ExtendLoanEventOptional":
         {
@@ -184,6 +167,46 @@
               "date",
               "id",
               "transactionHash",
+            ],
+          "type": "object",
+        },
+      'Omit<CoolerLoan,"request"|"creationEvents"|"defaultedClaimEvents"|"extendEvents"|"repaymentEvents">':
+        {
+          "properties":
+            {
+              "borrower": { "type": "string" },
+              "collateral": { "type": "number" },
+              "collateralToken": { "type": "string" },
+              "cooler": { "type": "string" },
+              "createdBlock": { "type": "number" },
+              "createdTimestamp": { "type": "number" },
+              "createdTransaction": { "type": "string" },
+              "debtToken": { "type": "string" },
+              "expiryTimestamp": { "type": "number" },
+              "hasCallback": { "type": "boolean" },
+              "id": { "type": "string" },
+              "interest": { "type": "number" },
+              "lender": { "type": "string" },
+              "loanId": { "type": "number" },
+              "principal": { "type": "number" },
+            },
+          "required":
+            [
+              "borrower",
+              "collateral",
+              "collateralToken",
+              "cooler",
+              "createdBlock",
+              "createdTimestamp",
+              "createdTransaction",
+              "debtToken",
+              "expiryTimestamp",
+              "hasCallback",
+              "id",
+              "interest",
+              "lender",
+              "loanId",
+              "principal",
             ],
           "type": "object",
         },

--- a/openapi/snapshot.yaml
+++ b/openapi/snapshot.yaml
@@ -320,6 +320,7 @@
                   "collateralIncome": { "type": "number" },
                   "coolerAddress": { "type": "string" },
                   "createdTimestamp": { "description": "Timestamp of the loan creation, in seconds", "type": "number" },
+                  "durationSeconds": { "description": "The loan duration, in seconds.", "type": "number" },
                   "expiryTimestamp":
                     { "description": "Timestamp of the expected loan expiry, in seconds", "type": "number" },
                   "id":
@@ -337,6 +338,8 @@
                       "description": "Cumulative interest paid on the loan.\n\nAny outstanding interest is paid first, followed by principal.",
                       "type": "number",
                     },
+                  "interestRate":
+                    { "description": "The interest rate, stored as a decimal.\n\ne.g. 0.5% = 0.005", "type": "number" },
                   "lenderAddress": { "type": "string" },
                   "loanId": { "description": "Loan id unique to the cooler", "type": "number" },
                   "principal":
@@ -359,10 +362,12 @@
                   "collateralIncome",
                   "coolerAddress",
                   "createdTimestamp",
+                  "durationSeconds",
                   "expiryTimestamp",
                   "id",
                   "interest",
                   "interestPaid",
+                  "interestRate",
                   "lenderAddress",
                   "loanId",
                   "principal",

--- a/openapi/snapshot.yaml
+++ b/openapi/snapshot.yaml
@@ -169,11 +169,22 @@
             {
               "blockNumber": { "type": "number" },
               "blockTimestamp": { "type": "number" },
+              "clearinghouseSDaiBalance": { "type": "number" },
+              "clearinghouseSDaiInDaiBalance": { "type": "number" },
               "date": { "type": "string" },
               "id": { "type": "string" },
               "transactionHash": { "type": "string" },
             },
-          "required": ["blockNumber", "blockTimestamp", "date", "id", "transactionHash"],
+          "required":
+            [
+              "blockNumber",
+              "blockTimestamp",
+              "clearinghouseSDaiBalance",
+              "clearinghouseSDaiInDaiBalance",
+              "date",
+              "id",
+              "transactionHash",
+            ],
           "type": "object",
         },
       'Omit<ExtendLoanEvent,"loan">':
@@ -182,6 +193,8 @@
             {
               "blockNumber": { "type": "number" },
               "blockTimestamp": { "type": "number" },
+              "clearinghouseSDaiBalance": { "type": "number" },
+              "clearinghouseSDaiInDaiBalance": { "type": "number" },
               "date": { "type": "string" },
               "expiryTimestamp": { "type": "number" },
               "id": { "type": "string" },
@@ -193,6 +206,8 @@
             [
               "blockNumber",
               "blockTimestamp",
+              "clearinghouseSDaiBalance",
+              "clearinghouseSDaiInDaiBalance",
               "date",
               "expiryTimestamp",
               "id",
@@ -209,6 +224,8 @@
               "amountPaid": { "type": "number" },
               "blockNumber": { "type": "number" },
               "blockTimestamp": { "type": "number" },
+              "clearinghouseSDaiBalance": { "type": "number" },
+              "clearinghouseSDaiInDaiBalance": { "type": "number" },
               "collateralDeposited": { "type": "number" },
               "date": { "type": "string" },
               "id": { "type": "string" },
@@ -222,6 +239,8 @@
               "amountPaid",
               "blockNumber",
               "blockTimestamp",
+              "clearinghouseSDaiBalance",
+              "clearinghouseSDaiInDaiBalance",
               "collateralDeposited",
               "date",
               "id",
@@ -250,6 +269,7 @@
     {
       "clearinghouse":
         {
+          "description": "Represents the state of the Clearinghouse at the time of the snapshot.",
           "properties":
             {
               "collateralAddress": { "type": "string" },
@@ -312,7 +332,11 @@
                       "description": "The total interest charged on the loan.\n\nWhen the loan is extended, this number will be increased.",
                       "type": "number",
                     },
-                  "interestPaid": { "description": "Cumulative interest paid on the loan.", "type": "number" },
+                  "interestPaid":
+                    {
+                      "description": "Cumulative interest paid on the loan.\n\nAny outstanding interest is paid first, followed by principal.",
+                      "type": "number",
+                    },
                   "lenderAddress": { "type": "string" },
                   "loanId": { "description": "Loan id unique to the cooler", "type": "number" },
                   "principal":
@@ -367,6 +391,7 @@
       "timestamp": { "description": "Timestamp of the snapshot, in milliseconds", "type": "number" },
       "treasury":
         {
+          "description": "Represents the state of the Treasury at the time of the snapshot.",
           "properties":
             {
               "daiBalance": { "type": "number" },

--- a/pulumi.ts
+++ b/pulumi.ts
@@ -57,7 +57,7 @@ const functionGenerate = new gcp.cloudfunctions.HttpCallbackFunction(
     timeout: 540,
     callback: handleGenerate,
     environmentVariables: {
-      GRAPHQL_ENDPOINT: "https://api.studio.thegraph.com/query/46563/cooler-loans/1.3.0",
+      GRAPHQL_ENDPOINT: "https://api.studio.thegraph.com/query/46563/cooler-loans/1.3.1",
     },
   },
   {

--- a/pulumi.ts
+++ b/pulumi.ts
@@ -57,7 +57,7 @@ const functionGenerate = new gcp.cloudfunctions.HttpCallbackFunction(
     timeout: 540,
     callback: handleGenerate,
     environmentVariables: {
-      GRAPHQL_ENDPOINT: "https://api.studio.thegraph.com/query/46563/cooler-loans/1.2.0",
+      GRAPHQL_ENDPOINT: "https://api.studio.thegraph.com/query/46563/cooler-loans/1.3.0",
     },
   },
   {

--- a/src/functions/generate/__tests__/snapshot.test.ts
+++ b/src/functions/generate/__tests__/snapshot.test.ts
@@ -286,6 +286,9 @@ describe("generateSnapshots", () => {
     expect(snapshotOne.extendEvents.length).toEqual(0);
     expect(snapshotOne.clearinghouseEvents.length).toEqual(1);
 
+    // Clearinghouse balance should have the new loan amount deducted
+    expect(snapshotOne.clearinghouse.sDaiInDaiBalance).toEqual(CLEARINGHOUSE_SDAI_IN_DAI_BALANCE - LOAN_PRINCIPAL);
+
     const snapshotTwo = snapshots[1];
     expect(snapshotTwo.date.toISOString()).toEqual("2023-08-02T23:59:59.999Z");
     expect(snapshotTwo.principalReceivables).toEqual(LOAN_PRINCIPAL);
@@ -315,6 +318,9 @@ describe("generateSnapshots", () => {
     expect(snapshotTwo.defaultedClaimEvents.length).toEqual(0);
     expect(snapshotTwo.extendEvents.length).toEqual(0);
     expect(snapshotTwo.clearinghouseEvents.length).toEqual(0);
+
+    // Clearinghouse balance should have the new loan amount deducted
+    expect(snapshotTwo.clearinghouse.sDaiInDaiBalance).toEqual(CLEARINGHOUSE_SDAI_IN_DAI_BALANCE - LOAN_PRINCIPAL);
   });
 
   it("multiple loans", () => {
@@ -387,7 +393,7 @@ describe("generateSnapshots", () => {
     expect(snapshotTwo.principalReceivables).toEqual(
       snapshotTwoLoanOne.principal -
       snapshotTwoLoanOne.principalPaid +
-      snapshotTwoLoanTwo.principal +
+      snapshotTwoLoanTwo.principal -
       snapshotTwoLoanTwo.principalPaid,
     );
 
@@ -458,6 +464,11 @@ describe("generateSnapshots", () => {
     expect(snapshotTen.defaultedClaimEvents.length).toEqual(0);
     expect(snapshotTen.extendEvents.length).toEqual(0);
     expect(snapshotTen.clearinghouseEvents.length).toEqual(0);
+
+    // Repayment of interest should be reflected in the clearinghouse
+    expect(snapshotTen.clearinghouse.sDaiInDaiBalance).toEqual(
+      CLEARINGHOUSE_SDAI_IN_DAI_BALANCE - LOAN_PRINCIPAL + REPAYMENT_AMOUNT,
+    );
 
     // Day after should be the same
     const snapshotEleven = snapshots[10];
@@ -561,6 +572,9 @@ describe("generateSnapshots", () => {
     expect(snapshotTwelve.defaultedClaimEvents.length).toEqual(0);
     expect(snapshotTwelve.extendEvents.length).toEqual(0);
     expect(snapshotTwelve.clearinghouseEvents.length).toEqual(0);
+
+    // Repayment of principal and interest should be reflected in the clearinghouse
+    expect(snapshotTwelve.clearinghouse.sDaiInDaiBalance).toEqual(CLEARINGHOUSE_SDAI_IN_DAI_BALANCE + LOAN_INTEREST);
   });
 
   it("clearinghouse balances", () => {
@@ -581,7 +595,7 @@ describe("generateSnapshots", () => {
 
     expect(snapshotOne.clearinghouse.daiBalance).toEqual(CLEARINGHOUSE_DAI_BALANCE);
     expect(snapshotOne.clearinghouse.sDaiBalance).toEqual(CLEARINGHOUSE_SDAI_BALANCE);
-    expect(snapshotOne.clearinghouse.sDaiInDaiBalance).toEqual(CLEARINGHOUSE_SDAI_IN_DAI_BALANCE);
+    expect(snapshotOne.clearinghouse.sDaiInDaiBalance).toEqual(CLEARINGHOUSE_SDAI_IN_DAI_BALANCE - LOAN_PRINCIPAL);
     expect(snapshotOne.clearinghouse.fundAmount).toEqual(CLEARINGHOUSE_FUND_AMOUNT);
     expect(snapshotOne.clearinghouse.fundCadence).toEqual(CLEARINGHOUSE_FUND_CADENCE);
     expect(snapshotOne.clearinghouse.coolerFactoryAddress).toEqual(CLEARINGHOUSE_COOLER_FACTORY_ADDRESS);
@@ -1123,6 +1137,11 @@ describe("generateSnapshots", () => {
     expect(snapshotTwo.defaultedClaimEvents.length).toEqual(0);
     expect(snapshotTwo.extendEvents.length).toEqual(1);
     expect(snapshotTwo.clearinghouseEvents.length).toEqual(0);
+
+    // Income from extension reflected in the clearinghouse balances
+    expect(snapshotTwo.clearinghouse.sDaiInDaiBalance).toEqual(
+      CLEARINGHOUSE_SDAI_IN_DAI_BALANCE - LOAN_PRINCIPAL + newInterest,
+    );
   });
 
   it("loan repayment then extension", () => {

--- a/src/functions/generate/__tests__/snapshot.test.ts
+++ b/src/functions/generate/__tests__/snapshot.test.ts
@@ -425,7 +425,12 @@ describe("generateSnapshots", () => {
     expect(snapshotTwoLoanTwo.interestPaid).toEqual(0);
 
     // eslint-disable-next-line prettier/prettier
-    expect(snapshotTwo.principalReceivables).toEqual(snapshotTwoLoanOne.principal - snapshotTwoLoanOne.principalPaid + snapshotTwoLoanTwo.principal - snapshotTwoLoanTwo.principalPaid);
+    expect(snapshotTwo.principalReceivables).toEqual(
+      snapshotTwoLoanOne.principal -
+        snapshotTwoLoanOne.principalPaid +
+        snapshotTwoLoanTwo.principal -
+        snapshotTwoLoanTwo.principalPaid,
+    );
 
     // Skip to day 10 after payment
     const snapshotTen = snapshots[9];
@@ -442,7 +447,12 @@ describe("generateSnapshots", () => {
     expect(snapshotTenLoanTwo.id).toEqual("0x3-1");
 
     // eslint-disable-next-line prettier/prettier
-    expect(snapshotTen.principalReceivables).toEqual(snapshotTenLoanOne.principal - snapshotTenLoanOne.principalPaid + snapshotTenLoanTwo.principal + snapshotTenLoanTwo.principalPaid);
+    expect(snapshotTen.principalReceivables).toEqual(
+      snapshotTenLoanOne.principal -
+        snapshotTenLoanOne.principalPaid +
+        snapshotTenLoanTwo.principal +
+        snapshotTenLoanTwo.principalPaid,
+    );
   });
 
   it("loan repayment < interest due", () => {

--- a/src/functions/generate/__tests__/storage.test.ts
+++ b/src/functions/generate/__tests__/storage.test.ts
@@ -77,17 +77,28 @@ describe("writeSnapshots", () => {
     const snapshots: Snapshot[] = [
       {
         date: new Date("2020-01-01"),
+        timestamp: new Date("2020-01-01").getTime(),
         principalReceivables: 0,
         interestReceivables: 0,
         clearinghouse: {
           daiBalance: 0,
           sDaiBalance: 0,
           sDaiInDaiBalance: 0,
+          fundAmount: 0,
+          fundCadence: 0,
+          coolerFactoryAddress: "",
+          collateralAddress: "",
+          debtAddress: "",
         },
         treasury: {
           daiBalance: 0,
           sDaiBalance: 0,
           sDaiInDaiBalance: 0,
+        },
+        terms: {
+          interestRate: 0,
+          duration: 0,
+          loanToCollateral: 0,
         },
         loans: {},
         creationEvents: [],
@@ -95,20 +106,34 @@ describe("writeSnapshots", () => {
         repaymentEvents: [],
         extendEvents: [],
         clearinghouseEvents: [],
+        interestIncome: 0,
+        collateralIncome: 0,
+        collateralDeposited: 0,
       },
       {
         date: new Date("2020-01-02"),
+        timestamp: new Date("2020-01-02").getTime(),
         principalReceivables: 0,
         interestReceivables: 0,
         clearinghouse: {
           daiBalance: 0,
           sDaiBalance: 0,
           sDaiInDaiBalance: 0,
+          fundAmount: 0,
+          fundCadence: 0,
+          coolerFactoryAddress: "",
+          collateralAddress: "",
+          debtAddress: "",
         },
         treasury: {
           daiBalance: 0,
           sDaiBalance: 0,
           sDaiInDaiBalance: 0,
+        },
+        terms: {
+          interestRate: 0,
+          duration: 0,
+          loanToCollateral: 0,
         },
         loans: {},
         creationEvents: [],
@@ -116,6 +141,9 @@ describe("writeSnapshots", () => {
         repaymentEvents: [],
         extendEvents: [],
         clearinghouseEvents: [],
+        interestIncome: 0,
+        collateralIncome: 0,
+        collateralDeposited: 0,
       },
     ];
 

--- a/src/functions/generate/events.graphql
+++ b/src/functions/generate/events.graphql
@@ -44,6 +44,8 @@ query CoolerLoanEvents($startTimestamp: BigInt!, $beforeTimestamp: BigInt!) {
       loanId
       principal
     }
+    clearinghouseSDaiBalance
+    clearinghouseSDaiInDaiBalance
   }
   defundEvents(
     where: { blockTimestamp_gte: $startTimestamp, blockTimestamp_lt: $beforeTimestamp }
@@ -99,6 +101,8 @@ query CoolerLoanEvents($startTimestamp: BigInt!, $beforeTimestamp: BigInt!) {
     loan {
       id
     }
+    clearinghouseSDaiBalance
+    clearinghouseSDaiInDaiBalance
   }
   rebalanceEvents(
     where: { blockTimestamp_gte: $startTimestamp, blockTimestamp_lt: $beforeTimestamp }
@@ -156,5 +160,7 @@ query CoolerLoanEvents($startTimestamp: BigInt!, $beforeTimestamp: BigInt!) {
     loan {
       id
     }
+    clearinghouseSDaiBalance
+    clearinghouseSDaiInDaiBalance
   }
 }

--- a/src/functions/generate/events.graphql
+++ b/src/functions/generate/events.graphql
@@ -43,6 +43,10 @@ query CoolerLoanEvents($startTimestamp: BigInt!, $beforeTimestamp: BigInt!) {
       lender
       loanId
       principal
+      request {
+        interestPercentage
+        durationSeconds
+      }
     }
     clearinghouseSDaiBalance
     clearinghouseSDaiInDaiBalance

--- a/src/functions/generate/index.ts
+++ b/src/functions/generate/index.ts
@@ -8,16 +8,8 @@ const LAUNCH_DATE = "2023-09-21";
 // So that the next 4 months of income can be projected
 const DAYS_AFTER = 121;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const handleGenerate = async (req: any, res: any) => {
-  // Determine the last cached date in Firestore
-  const lastCachedDate: string | null = await getLatestCachedDate();
-  const startDate: Date = setMidnight(
-    lastCachedDate
-      ? adjustDate(new Date(lastCachedDate), -1) // If there is a cached date, use the day before to catch anything in between
-      : new Date(LAUNCH_DATE), // Otherwise, use the launch date
-  );
-  const beforeDate: Date = setMidnight(adjustDate(new Date(), DAYS_AFTER));
+const run = async (startDate: Date, beforeDate: Date) => {
+  console.log(`Generating snapshots from ${startDate.toISOString()} to ${beforeDate.toISOString()}`);
 
   const endpointUrl = process.env.GRAPHQL_ENDPOINT;
   if (!endpointUrl) {
@@ -28,13 +20,41 @@ export const handleGenerate = async (req: any, res: any) => {
   const subgraphData = await getData(endpointUrl, startDate, beforeDate);
 
   // Grab the previous date's data
-  const previousSnapshot: Snapshot | null = await getSnapshot(startDate);
+  const previousSnapshot: Snapshot | null = await getSnapshot(adjustDate(startDate, -1));
 
   // Prepare snapshots
   const dateSnapshots = generateSnapshots(startDate, beforeDate, previousSnapshot, subgraphData);
 
   // Write snapshots
   await writeSnapshots(dateSnapshots);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const handleGenerate = async (req: any, res: any) => {
+  // Determine the last cached date in Firestore
+  const lastCachedDate: string | null = await getLatestCachedDate();
+  const startDate: Date = setMidnight(
+    // Is the last cached date before the current date?
+    lastCachedDate
+      ? new Date(lastCachedDate) < new Date()
+        ? adjustDate(new Date(lastCachedDate), -1) // If there is a cached date, use the day before to catch anything in between
+        : new Date() // Otherwise, use the current date
+      : new Date(LAUNCH_DATE), // Otherwise, use the launch date
+  );
+  const beforeDate: Date = setMidnight(adjustDate(new Date(), DAYS_AFTER));
+
+  let currentStartDate = new Date(startDate);
+  let currentEndDate = adjustDate(new Date(startDate), 7);
+
+  // Generate snapshots for every 7 days
+  // This avoids having too many records in memory at once
+  // and fetching too many records over GraphQL
+  while (currentEndDate < beforeDate) {
+    await run(currentStartDate, currentEndDate);
+
+    currentStartDate = adjustDate(currentStartDate, 7);
+    currentEndDate = adjustDate(currentEndDate, 7);
+  }
 
   // Required to end the function
   res.send("OK").end();

--- a/src/functions/generate/snapshot.ts
+++ b/src/functions/generate/snapshot.ts
@@ -337,6 +337,8 @@ export const generateSnapshots = (
           collateralIncome: 0,
           collateralClaimedQuantity: 0,
           collateralClaimedValue: 0,
+          interestRate: creationEvent.loan.request.interestPercentage,
+          durationSeconds: creationEvent.loan.request.durationSeconds,
         };
 
         // Adjust the clearinghouse balance to reflect the value at the time of the event
@@ -424,7 +426,9 @@ export const generateSnapshots = (
         // Additional interest is paid at the time a loan is extended
         // No impact on receivables
         // https://github.com/ohmzeus/Cooler/pull/63
-        const newInterest = parseNumber(extendEvent.periods) * (loan.interest - loan.interestPaid);
+        const interestPerPeriod =
+          ((loan.principal - loan.principalPaid) * loan.interestRate * loan.durationSeconds) / (365 * 24 * 60 * 60);
+        const newInterest = parseNumber(extendEvent.periods) * interestPerPeriod;
         loan.interest += newInterest;
         loan.interestPaid += newInterest;
 

--- a/src/functions/generate/snapshot.ts
+++ b/src/functions/generate/snapshot.ts
@@ -428,6 +428,11 @@ export const generateSnapshots = (
         // https://github.com/ohmzeus/Cooler/pull/63
         const interestPerPeriod =
           ((loan.principal - loan.principalPaid) * loan.interestRate * loan.durationSeconds) / (365 * 24 * 60 * 60);
+        console.log(
+          `${FUNC}: interestPerPeriod for loan ${loan.id} on remaining principal ${
+            loan.principal - loan.principalPaid
+          }: ${interestPerPeriod}`,
+        );
         const newInterest = parseNumber(extendEvent.periods) * interestPerPeriod;
         loan.interest += newInterest;
         loan.interestPaid += newInterest;

--- a/src/functions/generate/snapshot.ts
+++ b/src/functions/generate/snapshot.ts
@@ -224,6 +224,9 @@ export const generateSnapshots = (
         collateralClaimedQuantity: 0,
         collateralClaimedValue: 0,
       };
+
+      // Adjust the clearinghouse balance to reflect the principal transferred out
+      currentSnapshot.clearinghouse.sDaiInDaiBalance -= parseNumber(creationEvent.loan.principal);
     });
 
     // Update loans where there were repayment events
@@ -254,6 +257,9 @@ export const generateSnapshots = (
 
       // Set the income from the repayment
       currentSnapshot.interestIncome += interestRepayment;
+
+      // Adjust the clearinghouse balance to reflect the principal+interest transferred in
+      currentSnapshot.clearinghouse.sDaiInDaiBalance += interestRepayment + principalRepayment;
     });
 
     // Update loans where there were defaulted claim events
@@ -308,6 +314,9 @@ export const generateSnapshots = (
 
       // The interest income is updated
       currentSnapshot.interestIncome += newInterest;
+
+      // Adjust the clearinghouse balance to reflect the principal+interest transferred in
+      currentSnapshot.clearinghouse.sDaiInDaiBalance += newInterest;
     });
 
     // Update secondsToExpiry and status for all loans

--- a/src/functions/generate/snapshot.ts
+++ b/src/functions/generate/snapshot.ts
@@ -225,8 +225,9 @@ export const generateSnapshots = (
         collateralClaimedValue: 0,
       };
 
-      // Adjust the clearinghouse balance to reflect the principal transferred out
-      currentSnapshot.clearinghouse.sDaiInDaiBalance -= parseNumber(creationEvent.loan.principal);
+      // Adjust the clearinghouse balance to reflect the value at the time of the event
+      currentSnapshot.clearinghouse.sDaiBalance = parseNumber(creationEvent.clearinghouseSDaiBalance);
+      currentSnapshot.clearinghouse.sDaiInDaiBalance = parseNumber(creationEvent.clearinghouseSDaiInDaiBalance);
     });
 
     // Update loans where there were repayment events
@@ -258,8 +259,9 @@ export const generateSnapshots = (
       // Set the income from the repayment
       currentSnapshot.interestIncome += interestRepayment;
 
-      // Adjust the clearinghouse balance to reflect the principal+interest transferred in
-      currentSnapshot.clearinghouse.sDaiInDaiBalance += interestRepayment + principalRepayment;
+      // Adjust the clearinghouse balance to reflect the value at the time of the event
+      currentSnapshot.clearinghouse.sDaiBalance = parseNumber(repaymentEvent.clearinghouseSDaiBalance);
+      currentSnapshot.clearinghouse.sDaiInDaiBalance = parseNumber(repaymentEvent.clearinghouseSDaiInDaiBalance);
     });
 
     // Update loans where there were defaulted claim events
@@ -315,8 +317,9 @@ export const generateSnapshots = (
       // The interest income is updated
       currentSnapshot.interestIncome += newInterest;
 
-      // Adjust the clearinghouse balance to reflect the principal+interest transferred in
-      currentSnapshot.clearinghouse.sDaiInDaiBalance += newInterest;
+      // Adjust the clearinghouse balance to reflect the value at the time of the event
+      currentSnapshot.clearinghouse.sDaiBalance = parseNumber(extendEvent.clearinghouseSDaiBalance);
+      currentSnapshot.clearinghouse.sDaiInDaiBalance = parseNumber(extendEvent.clearinghouseSDaiInDaiBalance);
     });
 
     // Update secondsToExpiry and status for all loans

--- a/src/functions/generate/snapshot.ts
+++ b/src/functions/generate/snapshot.ts
@@ -1,7 +1,14 @@
 import { adjustDate, getISO8601DateString, setBeforeMidnight, setMidnight } from "../../helpers/dateHelper";
 import { parseNumber } from "../../helpers/numberHelper";
 import { Loan, Snapshot } from "../../types/snapshot";
-import { SubgraphData } from "../../types/subgraph";
+import {
+  ClaimDefaultedLoanEventOptional,
+  ClearinghouseSnapshotOptional,
+  ClearLoanRequestEventOptional,
+  ExtendLoanEventOptional,
+  RepayLoanEventOptional,
+  SubgraphData,
+} from "../../types/subgraph";
 
 const calculateInterestRepayment = (repayment: number, loan: Loan): number => {
   console.log(`repayment is ${repayment}`);
@@ -144,6 +151,103 @@ const getSecondsToExpiry = (currentDate: Date, expiryTimestamp: number): number 
   return Math.floor(timestampDifference / 1000);
 };
 
+type EventsByTimestamp = Record<
+  number,
+  {
+    clearinghouseSnapshots: ClearinghouseSnapshotOptional[];
+    creationEvents: ClearLoanRequestEventOptional[];
+    repaymentEvents: RepayLoanEventOptional[];
+    defaultedClaimEvents: ClaimDefaultedLoanEventOptional[];
+    extendEvents: ExtendLoanEventOptional[];
+  }
+>;
+
+const populateEventsByTimestamp = (currentDateString: string, subgraphData: SubgraphData): EventsByTimestamp => {
+  const dateEventsByTimestamp: EventsByTimestamp = {};
+
+  const currentClearinghouseSnapshots = subgraphData.clearinghouseSnapshots[currentDateString] || [];
+  currentClearinghouseSnapshots.forEach(clearinghouseSnapshot => {
+    const timestamp = parseNumber(clearinghouseSnapshot.blockTimestamp);
+    if (!dateEventsByTimestamp[timestamp]) {
+      dateEventsByTimestamp[timestamp] = {
+        clearinghouseSnapshots: [],
+        creationEvents: [],
+        repaymentEvents: [],
+        defaultedClaimEvents: [],
+        extendEvents: [],
+      };
+    }
+    dateEventsByTimestamp[timestamp].clearinghouseSnapshots.push(clearinghouseSnapshot);
+  });
+
+  const currentCreationEvents = subgraphData.creationEvents[currentDateString] || [];
+  currentCreationEvents.forEach(creationEvent => {
+    const timestamp = parseNumber(creationEvent.blockTimestamp);
+    if (!dateEventsByTimestamp[timestamp]) {
+      dateEventsByTimestamp[timestamp] = {
+        clearinghouseSnapshots: [],
+        creationEvents: [],
+        repaymentEvents: [],
+        defaultedClaimEvents: [],
+        extendEvents: [],
+      };
+    }
+    dateEventsByTimestamp[timestamp].creationEvents.push(creationEvent);
+  });
+
+  const currentRepaymentEvents = subgraphData.repaymentEvents[currentDateString] || [];
+  currentRepaymentEvents.forEach(repaymentEvent => {
+    const timestamp = parseNumber(repaymentEvent.blockTimestamp);
+    if (!dateEventsByTimestamp[timestamp]) {
+      dateEventsByTimestamp[timestamp] = {
+        clearinghouseSnapshots: [],
+        creationEvents: [],
+        repaymentEvents: [],
+        defaultedClaimEvents: [],
+        extendEvents: [],
+      };
+    }
+    dateEventsByTimestamp[timestamp].repaymentEvents.push(repaymentEvent);
+  });
+
+  const currentDefaultedClaimEvents = subgraphData.defaultedClaimEvents[currentDateString] || [];
+  currentDefaultedClaimEvents.forEach(defaultedClaimEvent => {
+    const timestamp = parseNumber(defaultedClaimEvent.blockTimestamp);
+    if (!dateEventsByTimestamp[timestamp]) {
+      dateEventsByTimestamp[timestamp] = {
+        clearinghouseSnapshots: [],
+        creationEvents: [],
+        repaymentEvents: [],
+        defaultedClaimEvents: [],
+        extendEvents: [],
+      };
+    }
+    dateEventsByTimestamp[timestamp].defaultedClaimEvents.push(defaultedClaimEvent);
+  });
+
+  const currentExtendEvents = subgraphData.extendEvents[currentDateString] || [];
+  currentExtendEvents.forEach(extendEvent => {
+    const timestamp = parseNumber(extendEvent.blockTimestamp);
+    if (!dateEventsByTimestamp[timestamp]) {
+      dateEventsByTimestamp[timestamp] = {
+        clearinghouseSnapshots: [],
+        creationEvents: [],
+        repaymentEvents: [],
+        defaultedClaimEvents: [],
+        extendEvents: [],
+      };
+    }
+    dateEventsByTimestamp[timestamp].extendEvents.push(extendEvent);
+  });
+
+  // Sort the events by timestamp
+  Object.entries(dateEventsByTimestamp).sort((a, b) => {
+    return parseInt(a[0]) - parseInt(b[0]);
+  });
+
+  return dateEventsByTimestamp;
+};
+
 export const generateSnapshots = (
   startDate: Date,
   beforeDate: Date,
@@ -170,157 +274,174 @@ export const generateSnapshots = (
     // Populate a new Snapshot based on the previous one
     const currentSnapshot = createSnapshot(currentDateBeforeMidnight, previousSnapshot);
 
-    // Update clearinghouse data, if it exists
-    const currentClearinghouseSnapshots = subgraphData.clearinghouseSnapshots[currentDateString] || [];
-    console.log(`${FUNC}: processing ${currentClearinghouseSnapshots.length} clearinghouse snapshots`);
-    currentClearinghouseSnapshots.forEach(clearinghouseSnapshot => {
-      console.log(`${FUNC}: processing clearinghouse snapshot ${clearinghouseSnapshot.id}`);
+    // Order all events by block timestamp
+    const currentDateEventsByTimestamp: EventsByTimestamp = populateEventsByTimestamp(currentDateString, subgraphData);
 
-      // If there are multiple snapshots in a day, successive ones will overwrite the previous values
-      currentSnapshot.clearinghouse.daiBalance = parseNumber(clearinghouseSnapshot.daiBalance);
-      currentSnapshot.clearinghouse.sDaiBalance = parseNumber(clearinghouseSnapshot.sDaiBalance);
-      currentSnapshot.clearinghouse.sDaiInDaiBalance = parseNumber(clearinghouseSnapshot.sDaiInDaiBalance);
-      currentSnapshot.clearinghouse.fundAmount = parseNumber(clearinghouseSnapshot.fundAmount);
-      currentSnapshot.clearinghouse.fundCadence = parseNumber(clearinghouseSnapshot.fundCadence);
-      currentSnapshot.clearinghouse.coolerFactoryAddress = clearinghouseSnapshot.coolerFactoryAddress;
-      currentSnapshot.clearinghouse.collateralAddress = clearinghouseSnapshot.collateralAddress;
-      currentSnapshot.clearinghouse.debtAddress = clearinghouseSnapshot.debtAddress;
+    // Iterate by timestamp, so that events are processed in order
+    for (const [timestamp, records] of Object.entries(currentDateEventsByTimestamp)) {
+      console.log(`${FUNC}: processing events for timestamp ${getISO8601DateString(new Date(parseInt(timestamp)))})}`);
 
-      currentSnapshot.treasury.daiBalance = parseNumber(clearinghouseSnapshot.treasuryDaiBalance);
-      currentSnapshot.treasury.sDaiBalance = parseNumber(clearinghouseSnapshot.treasurySDaiBalance);
-      currentSnapshot.treasury.sDaiInDaiBalance = parseNumber(clearinghouseSnapshot.treasurySDaiInDaiBalance);
+      // Update clearinghouse data, if it exists
+      const currentClearinghouseSnapshots = records.clearinghouseSnapshots;
+      console.log(`${FUNC}: processing ${currentClearinghouseSnapshots.length} clearinghouse snapshots`);
+      currentClearinghouseSnapshots.forEach(clearinghouseSnapshot => {
+        console.log(`${FUNC}: processing clearinghouse snapshot ${clearinghouseSnapshot.id}`);
 
-      currentSnapshot.terms.interestRate = parseNumber(clearinghouseSnapshot.interestRate);
-      currentSnapshot.terms.duration = parseNumber(clearinghouseSnapshot.duration);
-      currentSnapshot.terms.loanToCollateral = parseNumber(clearinghouseSnapshot.loanToCollateral);
+        // If there are multiple snapshots in a day, successive ones will overwrite the previous values
+        currentSnapshot.clearinghouse.daiBalance = parseNumber(clearinghouseSnapshot.daiBalance);
+        currentSnapshot.clearinghouse.sDaiBalance = parseNumber(clearinghouseSnapshot.sDaiBalance);
+        currentSnapshot.clearinghouse.sDaiInDaiBalance = parseNumber(clearinghouseSnapshot.sDaiInDaiBalance);
+        currentSnapshot.clearinghouse.fundAmount = parseNumber(clearinghouseSnapshot.fundAmount);
+        currentSnapshot.clearinghouse.fundCadence = parseNumber(clearinghouseSnapshot.fundCadence);
+        currentSnapshot.clearinghouse.coolerFactoryAddress = clearinghouseSnapshot.coolerFactoryAddress;
+        currentSnapshot.clearinghouse.collateralAddress = clearinghouseSnapshot.collateralAddress;
+        currentSnapshot.clearinghouse.debtAddress = clearinghouseSnapshot.debtAddress;
 
-      currentSnapshot.clearinghouseEvents.push(clearinghouseSnapshot);
-    });
+        currentSnapshot.treasury.daiBalance = parseNumber(clearinghouseSnapshot.treasuryDaiBalance);
+        currentSnapshot.treasury.sDaiBalance = parseNumber(clearinghouseSnapshot.treasurySDaiBalance);
+        currentSnapshot.treasury.sDaiInDaiBalance = parseNumber(clearinghouseSnapshot.treasurySDaiInDaiBalance);
 
-    // Create loans where there were creation events
-    const currentCreationEvents = subgraphData.creationEvents[currentDateString] || [];
-    console.log(`${FUNC}: processing ${currentCreationEvents.length} creation events`);
-    currentCreationEvents.forEach(creationEvent => {
-      console.log(`${FUNC}: processing creation event ${creationEvent.id}`);
+        currentSnapshot.terms.interestRate = parseNumber(clearinghouseSnapshot.interestRate);
+        currentSnapshot.terms.duration = parseNumber(clearinghouseSnapshot.duration);
+        currentSnapshot.terms.loanToCollateral = parseNumber(clearinghouseSnapshot.loanToCollateral);
 
-      // Add any new loans into running list
-      console.log(`${FUNC}: creationEvent.loan.id: ${creationEvent.loan.id}`);
-      currentSnapshot.loans[creationEvent.loan.id] = {
-        id: creationEvent.loan.id,
-        loanId: parseNumber(creationEvent.loan.loanId),
-        createdTimestamp: parseNumber(creationEvent.blockTimestamp),
-        coolerAddress: creationEvent.loan.cooler,
-        borrowerAddress: creationEvent.loan.borrower,
-        lenderAddress: creationEvent.loan.lender,
-        principal: parseNumber(creationEvent.loan.principal),
-        interest: parseNumber(creationEvent.loan.interest),
-        collateralDeposited: parseNumber(creationEvent.loan.collateral),
-        expiryTimestamp: parseNumber(creationEvent.loan.expiryTimestamp),
-        secondsToExpiry: getSecondsToExpiry(currentDateBeforeMidnight, parseNumber(creationEvent.loan.expiryTimestamp)),
-        status: "Active",
-        principalPaid: 0,
-        interestPaid: 0,
-        collateralIncome: 0,
-        collateralClaimedQuantity: 0,
-        collateralClaimedValue: 0,
-      };
+        currentSnapshot.clearinghouseEvents.push(clearinghouseSnapshot);
+      });
 
-      // Adjust the clearinghouse balance to reflect the value at the time of the event
-      currentSnapshot.clearinghouse.sDaiBalance = parseNumber(creationEvent.clearinghouseSDaiBalance);
-      currentSnapshot.clearinghouse.sDaiInDaiBalance = parseNumber(creationEvent.clearinghouseSDaiInDaiBalance);
-    });
+      // Create loans where there were creation events
+      const currentCreationEvents = records.creationEvents;
+      console.log(`${FUNC}: processing ${currentCreationEvents.length} creation events`);
+      currentCreationEvents.forEach(creationEvent => {
+        console.log(`${FUNC}: processing creation event ${creationEvent.id}`);
 
-    // Update loans where there were repayment events
-    const currentRepaymentEvents = subgraphData.repaymentEvents[currentDateString] || [];
-    console.log(`${FUNC}: processing ${currentRepaymentEvents.length} repayment events`);
-    currentRepaymentEvents.forEach(repaymentEvent => {
-      console.log(`${FUNC}: processing repayment event ${repaymentEvent.id}`);
+        // Add any new loans into running list
+        console.log(`${FUNC}: creationEvent.loan.id: ${creationEvent.loan.id}`);
+        currentSnapshot.loans[creationEvent.loan.id] = {
+          id: creationEvent.loan.id,
+          loanId: parseNumber(creationEvent.loan.loanId),
+          createdTimestamp: parseNumber(creationEvent.blockTimestamp),
+          coolerAddress: creationEvent.loan.cooler,
+          borrowerAddress: creationEvent.loan.borrower,
+          lenderAddress: creationEvent.loan.lender,
+          principal: parseNumber(creationEvent.loan.principal),
+          interest: parseNumber(creationEvent.loan.interest),
+          collateralDeposited: parseNumber(creationEvent.loan.collateral),
+          expiryTimestamp: parseNumber(creationEvent.loan.expiryTimestamp),
+          secondsToExpiry: getSecondsToExpiry(
+            currentDateBeforeMidnight,
+            parseNumber(creationEvent.loan.expiryTimestamp),
+          ),
+          status: "Active",
+          principalPaid: 0,
+          interestPaid: 0,
+          collateralIncome: 0,
+          collateralClaimedQuantity: 0,
+          collateralClaimedValue: 0,
+        };
 
-      // Find the loan
-      const loan = currentSnapshot.loans[repaymentEvent.loan.id];
-      if (!loan) {
-        throw new Error(`repaymentEvents: Could not find loan ${repaymentEvent.loan.id}`);
-      }
+        // Adjust the clearinghouse balance to reflect the value at the time of the event
+        currentSnapshot.clearinghouse.sDaiBalance = parseNumber(creationEvent.clearinghouseSDaiBalance);
+        currentSnapshot.clearinghouse.sDaiInDaiBalance = parseNumber(creationEvent.clearinghouseSDaiInDaiBalance);
+      });
 
-      // Update the loan state
-      loan.collateralDeposited = parseNumber(repaymentEvent.collateralDeposited);
+      // Update loans where there were repayment events
+      const currentRepaymentEvents = records.repaymentEvents;
+      console.log(`${FUNC}: processing ${currentRepaymentEvents.length} repayment events`);
+      currentRepaymentEvents.forEach(repaymentEvent => {
+        console.log(`${FUNC}: processing repayment event ${repaymentEvent.id}`);
 
-      // Calculate the interest and principal paid for this payment
-      const eventAmountPaid = parseNumber(repaymentEvent.amountPaid);
-      const interestRepayment = calculateInterestRepayment(eventAmountPaid, loan);
-      const principalRepayment = calculatePrincipalRepayment(eventAmountPaid, loan);
-      console.log(`${FUNC}: eventAmountPaid: ${eventAmountPaid}`);
-      console.log(`${FUNC}: interestRepayment: ${interestRepayment}`);
-      console.log(`${FUNC}: principalRepayment: ${principalRepayment}`);
+        // Find the loan
+        const loan = currentSnapshot.loans[repaymentEvent.loan.id];
+        if (!loan) {
+          throw new Error(`repaymentEvents: Could not find loan ${repaymentEvent.loan.id}`);
+        }
 
-      loan.interestPaid += interestRepayment;
-      loan.principalPaid += principalRepayment;
+        // Update the loan state
+        loan.collateralDeposited = parseNumber(repaymentEvent.collateralDeposited);
 
-      // Set the income from the repayment
-      currentSnapshot.interestIncome += interestRepayment;
+        // Calculate the interest and principal paid for this payment
+        const eventAmountPaid = parseNumber(repaymentEvent.amountPaid);
+        const interestRepayment = calculateInterestRepayment(eventAmountPaid, loan);
+        const principalRepayment = calculatePrincipalRepayment(eventAmountPaid, loan);
+        console.log(`${FUNC}: eventAmountPaid: ${eventAmountPaid}`);
+        console.log(`${FUNC}: interestRepayment: ${interestRepayment}`);
+        console.log(`${FUNC}: principalRepayment: ${principalRepayment}`);
 
-      // Adjust the clearinghouse balance to reflect the value at the time of the event
-      currentSnapshot.clearinghouse.sDaiBalance = parseNumber(repaymentEvent.clearinghouseSDaiBalance);
-      currentSnapshot.clearinghouse.sDaiInDaiBalance = parseNumber(repaymentEvent.clearinghouseSDaiInDaiBalance);
-    });
+        loan.interestPaid += interestRepayment;
+        loan.principalPaid += principalRepayment;
 
-    // Update loans where there were defaulted claim events
-    const currentDefaultedClaimEvents = subgraphData.defaultedClaimEvents[currentDateString] || [];
-    console.log(`${FUNC}: processing ${currentDefaultedClaimEvents.length} default claim events`);
-    currentDefaultedClaimEvents.forEach(defaultedClaimEvent => {
-      console.log(`${FUNC}: processing default claim event ${defaultedClaimEvent.id}`);
+        // Set the income from the repayment
+        currentSnapshot.interestIncome += interestRepayment;
 
-      // Find the loan
-      const loan = currentSnapshot.loans[defaultedClaimEvent.loan.id];
-      if (!loan) {
-        throw new Error(`defaultedClaim: Could not find loan ${defaultedClaimEvent.loan.id}`);
-      }
+        // Adjust the clearinghouse balance to reflect the value at the time of the event
+        currentSnapshot.clearinghouse.sDaiBalance = parseNumber(repaymentEvent.clearinghouseSDaiBalance);
+        currentSnapshot.clearinghouse.sDaiInDaiBalance = parseNumber(repaymentEvent.clearinghouseSDaiInDaiBalance);
+      });
 
-      const collateralValueClaimed = parseNumber(defaultedClaimEvent.collateralValueClaimed);
+      // Update loans where there were defaulted claim events
+      const currentDefaultedClaimEvents = records.defaultedClaimEvents;
+      console.log(`${FUNC}: processing ${currentDefaultedClaimEvents.length} default claim events`);
+      currentDefaultedClaimEvents.forEach(defaultedClaimEvent => {
+        console.log(`${FUNC}: processing default claim event ${defaultedClaimEvent.id}`);
 
-      // Update the loan
-      loan.status = "Reclaimed";
-      loan.collateralClaimedQuantity += parseNumber(defaultedClaimEvent.collateralQuantityClaimed);
-      loan.collateralClaimedValue += collateralValueClaimed;
-      loan.collateralDeposited = 0;
+        // Find the loan
+        const loan = currentSnapshot.loans[defaultedClaimEvent.loan.id];
+        if (!loan) {
+          throw new Error(`defaultedClaim: Could not find loan ${defaultedClaimEvent.loan.id}`);
+        }
 
-      // Calculate the income from the collateral claim
-      loan.collateralIncome += collateralValueClaimed;
+        const collateralValueClaimed = parseNumber(defaultedClaimEvent.collateralValueClaimed);
 
-      // Set the income from the default claim
-      currentSnapshot.collateralIncome += collateralValueClaimed;
-    });
+        // Update the loan
+        loan.status = "Reclaimed";
+        loan.collateralClaimedQuantity += parseNumber(defaultedClaimEvent.collateralQuantityClaimed);
+        loan.collateralClaimedValue += collateralValueClaimed;
+        loan.collateralDeposited = 0;
 
-    // Update loans where there were extend events
-    const currentExtendEvents = subgraphData.extendEvents[currentDateString] || [];
-    console.log(`${FUNC}: processing ${currentExtendEvents.length} extend events`);
-    currentExtendEvents.forEach(extendEvent => {
-      console.log(`${FUNC}: processing extend event ${extendEvent.id}`);
+        // Calculate the income from the collateral claim
+        loan.collateralIncome += collateralValueClaimed;
 
-      // Find the loan
-      const loan = currentSnapshot.loans[extendEvent.loan.id];
-      if (!loan) {
-        throw new Error(`extendEvents: Could not find loan ${extendEvent.loan.id}`);
-      }
+        // Set the income from the default claim
+        currentSnapshot.collateralIncome += collateralValueClaimed;
+      });
 
-      // Update the loan
-      loan.status = "Active";
-      loan.expiryTimestamp = parseNumber(extendEvent.expiryTimestamp);
+      // Update loans where there were extend events
+      const currentExtendEvents = records.extendEvents;
+      console.log(`${FUNC}: processing ${currentExtendEvents.length} extend events`);
+      currentExtendEvents.forEach(extendEvent => {
+        console.log(`${FUNC}: processing extend event ${extendEvent.id}`);
 
-      // Additional interest is paid at the time a loan is extended
-      // No impact on receivables
-      // https://github.com/ohmzeus/Cooler/pull/63
-      const newInterest = parseNumber(extendEvent.periods) * (loan.interest - loan.interestPaid);
-      loan.interest += newInterest;
-      loan.interestPaid += newInterest;
+        // Find the loan
+        const loan = currentSnapshot.loans[extendEvent.loan.id];
+        if (!loan) {
+          throw new Error(`extendEvents: Could not find loan ${extendEvent.loan.id}`);
+        }
 
-      // The interest income is updated
-      currentSnapshot.interestIncome += newInterest;
+        // Update the loan
+        loan.status = "Active";
+        loan.expiryTimestamp = parseNumber(extendEvent.expiryTimestamp);
 
-      // Adjust the clearinghouse balance to reflect the value at the time of the event
-      currentSnapshot.clearinghouse.sDaiBalance = parseNumber(extendEvent.clearinghouseSDaiBalance);
-      currentSnapshot.clearinghouse.sDaiInDaiBalance = parseNumber(extendEvent.clearinghouseSDaiInDaiBalance);
-    });
+        // Additional interest is paid at the time a loan is extended
+        // No impact on receivables
+        // https://github.com/ohmzeus/Cooler/pull/63
+        const newInterest = parseNumber(extendEvent.periods) * (loan.interest - loan.interestPaid);
+        loan.interest += newInterest;
+        loan.interestPaid += newInterest;
+
+        // The interest income is updated
+        currentSnapshot.interestIncome += newInterest;
+
+        // Adjust the clearinghouse balance to reflect the value at the time of the event
+        currentSnapshot.clearinghouse.sDaiBalance = parseNumber(extendEvent.clearinghouseSDaiBalance);
+        currentSnapshot.clearinghouse.sDaiInDaiBalance = parseNumber(extendEvent.clearinghouseSDaiInDaiBalance);
+      });
+
+      // Add all events
+      currentSnapshot.creationEvents.push(...currentCreationEvents);
+      currentSnapshot.repaymentEvents.push(...currentRepaymentEvents);
+      currentSnapshot.defaultedClaimEvents.push(...currentDefaultedClaimEvents);
+      currentSnapshot.extendEvents.push(...currentExtendEvents);
+    }
 
     // Update secondsToExpiry and status for all loans
     const loans = currentSnapshot.loans ? Object.values(currentSnapshot.loans) : [];
@@ -352,12 +473,6 @@ export const generateSnapshots = (
         currentSnapshot.principalReceivables += loan.principal - loan.principalPaid;
       }
     });
-
-    // Add all events
-    currentSnapshot.creationEvents.push(...currentCreationEvents);
-    currentSnapshot.repaymentEvents.push(...currentRepaymentEvents);
-    currentSnapshot.defaultedClaimEvents.push(...currentDefaultedClaimEvents);
-    currentSnapshot.extendEvents.push(...currentExtendEvents);
 
     snapshots.push(currentSnapshot);
 

--- a/src/functions/generate/snapshot.ts
+++ b/src/functions/generate/snapshot.ts
@@ -34,7 +34,7 @@ const createSnapshot = (currentDate: Date, previousSnapshot: Snapshot | null): S
   const FUNC = "createSnapshot";
   // If there is no previous snapshot, return a new one
   if (!previousSnapshot) {
-    console.log(`${FUNC}: No previous snapshot found for ${getISO8601DateString(currentDate)}`);
+    console.log(`${FUNC}: No previous snapshot found`);
     return {
       date: currentDate,
       timestamp: currentDate.getTime(),
@@ -72,8 +72,8 @@ const createSnapshot = (currentDate: Date, previousSnapshot: Snapshot | null): S
     };
   }
 
-  // Otherwise, return a new one based on the previous one
-  console.log(`${FUNC}: Previous snapshot for ${getISO8601DateString(currentDate)} found. Copying.`);
+  // Otherwise, return a new one based on the previous day
+  console.log(`${FUNC}: Previous snapshot for ${getISO8601DateString(previousSnapshot.date)} found. Copying.`);
   const newSnapshot = JSON.parse(JSON.stringify(previousSnapshot)) as Snapshot;
 
   // Set the current date

--- a/src/functions/generate/subgraph.ts
+++ b/src/functions/generate/subgraph.ts
@@ -66,7 +66,6 @@ export const getData = async (endpointUrl: string, startDate: Date, beforeDate: 
         accumulator[dateString] = [];
       }
 
-      console.log(`${FUNC}: Adding creation event with id ${currentValue.id} on date ${currentValue.date}`);
       accumulator[dateString].push(currentValue);
       return accumulator;
     },
@@ -91,7 +90,6 @@ export const getData = async (endpointUrl: string, startDate: Date, beforeDate: 
     },
     {} as { [key: string]: RepayLoanEventOptional[] },
   );
-  console.log(`${FUNC}: Found ${Object.keys(repaymentEvents).length} repayment events`);
 
   /**
    * Claim Default Events
@@ -111,7 +109,6 @@ export const getData = async (endpointUrl: string, startDate: Date, beforeDate: 
     },
     {} as { [key: string]: ClaimDefaultedLoanEventOptional[] },
   );
-  console.log(`${FUNC}: Found ${Object.keys(claimDefaultedEvents).length} default claim events`);
 
   /**
    * Extend Events
@@ -131,7 +128,6 @@ export const getData = async (endpointUrl: string, startDate: Date, beforeDate: 
     },
     {} as { [key: string]: ExtendLoanEventOptional[] },
   );
-  console.log(`${FUNC}: Found ${Object.keys(extendEvents).length} extension events`);
 
   return {
     clearinghouseSnapshots: clearinghouseSnapshots,

--- a/src/functions/generate/subgraph.ts
+++ b/src/functions/generate/subgraph.ts
@@ -14,7 +14,9 @@ import {
 } from "../../types/subgraph";
 
 export const getData = async (endpointUrl: string, startDate: Date, beforeDate: Date): Promise<SubgraphData> => {
+  const FUNC = "getData";
   // Fetch events
+  console.log(`${FUNC}: Fetching events from ${startDate.toISOString()} to ${beforeDate.toISOString()}`);
   const eventData: CoolerLoanEventsQuery = await request({
     url: endpointUrl,
     document: CoolerLoanEventsDocument,
@@ -64,6 +66,7 @@ export const getData = async (endpointUrl: string, startDate: Date, beforeDate: 
         accumulator[dateString] = [];
       }
 
+      console.log(`${FUNC}: Adding creation event with id ${currentValue.id} on date ${currentValue.date}`);
       accumulator[dateString].push(currentValue);
       return accumulator;
     },
@@ -88,6 +91,7 @@ export const getData = async (endpointUrl: string, startDate: Date, beforeDate: 
     },
     {} as { [key: string]: RepayLoanEventOptional[] },
   );
+  console.log(`${FUNC}: Found ${Object.keys(repaymentEvents).length} repayment events`);
 
   /**
    * Claim Default Events
@@ -107,6 +111,7 @@ export const getData = async (endpointUrl: string, startDate: Date, beforeDate: 
     },
     {} as { [key: string]: ClaimDefaultedLoanEventOptional[] },
   );
+  console.log(`${FUNC}: Found ${Object.keys(claimDefaultedEvents).length} default claim events`);
 
   /**
    * Extend Events
@@ -126,6 +131,7 @@ export const getData = async (endpointUrl: string, startDate: Date, beforeDate: 
     },
     {} as { [key: string]: ExtendLoanEventOptional[] },
   );
+  console.log(`${FUNC}: Found ${Object.keys(extendEvents).length} extension events`);
 
   return {
     clearinghouseSnapshots: clearinghouseSnapshots,

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -199,6 +199,8 @@ export enum ClaimDefaultedLoanEvent_OrderBy {
 export type ClearLoanRequestEvent = {
   blockNumber: Scalars["BigInt"]["output"];
   blockTimestamp: Scalars["BigInt"]["output"];
+  clearinghouseSDaiBalance: Scalars["BigDecimal"]["output"];
+  clearinghouseSDaiInDaiBalance: Scalars["BigDecimal"]["output"];
   date: Scalars["String"]["output"];
   id: Scalars["String"]["output"];
   loan: CoolerLoan;
@@ -226,6 +228,22 @@ export type ClearLoanRequestEvent_Filter = {
   blockTimestamp_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
   blockTimestamp_not?: InputMaybe<Scalars["BigInt"]["input"]>;
   blockTimestamp_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  clearinghouseSDaiBalance?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_gt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_gte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
+  clearinghouseSDaiBalance_lt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_lte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_not?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_not_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
+  clearinghouseSDaiInDaiBalance?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_gt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_gte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
+  clearinghouseSDaiInDaiBalance_lt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_lte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_not?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_not_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
   date?: InputMaybe<Scalars["String"]["input"]>;
   date_contains?: InputMaybe<Scalars["String"]["input"]>;
   date_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
@@ -324,6 +342,8 @@ export type ClearLoanRequestEvent_Filter = {
 export enum ClearLoanRequestEvent_OrderBy {
   BlockNumber = "blockNumber",
   BlockTimestamp = "blockTimestamp",
+  ClearinghouseSDaiBalance = "clearinghouseSDaiBalance",
+  ClearinghouseSDaiInDaiBalance = "clearinghouseSDaiInDaiBalance",
   Date = "date",
   Id = "id",
   Loan = "loan",
@@ -1292,6 +1312,8 @@ export enum DefundEvent_OrderBy {
 export type ExtendLoanEvent = {
   blockNumber: Scalars["BigInt"]["output"];
   blockTimestamp: Scalars["BigInt"]["output"];
+  clearinghouseSDaiBalance: Scalars["BigDecimal"]["output"];
+  clearinghouseSDaiInDaiBalance: Scalars["BigDecimal"]["output"];
   date: Scalars["String"]["output"];
   expiryTimestamp: Scalars["BigInt"]["output"];
   id: Scalars["String"]["output"];
@@ -1321,6 +1343,22 @@ export type ExtendLoanEvent_Filter = {
   blockTimestamp_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
   blockTimestamp_not?: InputMaybe<Scalars["BigInt"]["input"]>;
   blockTimestamp_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  clearinghouseSDaiBalance?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_gt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_gte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
+  clearinghouseSDaiBalance_lt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_lte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_not?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_not_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
+  clearinghouseSDaiInDaiBalance?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_gt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_gte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
+  clearinghouseSDaiInDaiBalance_lt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_lte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_not?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_not_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
   date?: InputMaybe<Scalars["String"]["input"]>;
   date_contains?: InputMaybe<Scalars["String"]["input"]>;
   date_contains_nocase?: InputMaybe<Scalars["String"]["input"]>;
@@ -1422,6 +1460,8 @@ export type ExtendLoanEvent_Filter = {
 export enum ExtendLoanEvent_OrderBy {
   BlockNumber = "blockNumber",
   BlockTimestamp = "blockTimestamp",
+  ClearinghouseSDaiBalance = "clearinghouseSDaiBalance",
+  ClearinghouseSDaiInDaiBalance = "clearinghouseSDaiInDaiBalance",
   Date = "date",
   ExpiryTimestamp = "expiryTimestamp",
   Id = "id",
@@ -1820,6 +1860,8 @@ export type RepayLoanEvent = {
   amountPaid: Scalars["BigDecimal"]["output"];
   blockNumber: Scalars["BigInt"]["output"];
   blockTimestamp: Scalars["BigInt"]["output"];
+  clearinghouseSDaiBalance: Scalars["BigDecimal"]["output"];
+  clearinghouseSDaiInDaiBalance: Scalars["BigDecimal"]["output"];
   collateralDeposited: Scalars["BigDecimal"]["output"];
   date: Scalars["String"]["output"];
   id: Scalars["String"]["output"];
@@ -1858,6 +1900,22 @@ export type RepayLoanEvent_Filter = {
   blockTimestamp_lte?: InputMaybe<Scalars["BigInt"]["input"]>;
   blockTimestamp_not?: InputMaybe<Scalars["BigInt"]["input"]>;
   blockTimestamp_not_in?: InputMaybe<Array<Scalars["BigInt"]["input"]>>;
+  clearinghouseSDaiBalance?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_gt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_gte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
+  clearinghouseSDaiBalance_lt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_lte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_not?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiBalance_not_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
+  clearinghouseSDaiInDaiBalance?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_gt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_gte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
+  clearinghouseSDaiInDaiBalance_lt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_lte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_not?: InputMaybe<Scalars["BigDecimal"]["input"]>;
+  clearinghouseSDaiInDaiBalance_not_in?: InputMaybe<Array<Scalars["BigDecimal"]["input"]>>;
   collateralDeposited?: InputMaybe<Scalars["BigDecimal"]["input"]>;
   collateralDeposited_gt?: InputMaybe<Scalars["BigDecimal"]["input"]>;
   collateralDeposited_gte?: InputMaybe<Scalars["BigDecimal"]["input"]>;
@@ -1968,6 +2026,8 @@ export enum RepayLoanEvent_OrderBy {
   AmountPaid = "amountPaid",
   BlockNumber = "blockNumber",
   BlockTimestamp = "blockTimestamp",
+  ClearinghouseSDaiBalance = "clearinghouseSDaiBalance",
+  ClearinghouseSDaiInDaiBalance = "clearinghouseSDaiInDaiBalance",
   CollateralDeposited = "collateralDeposited",
   Date = "date",
   Id = "id",
@@ -2508,6 +2568,8 @@ export type CoolerLoanEventsQuery = {
     date: string;
     id: string;
     transactionHash: string;
+    clearinghouseSDaiBalance: number;
+    clearinghouseSDaiInDaiBalance: number;
     loan: {
       borrower: string;
       collateral: number;
@@ -2569,6 +2631,8 @@ export type CoolerLoanEventsQuery = {
     interestDue: number;
     periods: number;
     transactionHash: string;
+    clearinghouseSDaiBalance: number;
+    clearinghouseSDaiInDaiBalance: number;
     loan: { id: string };
   }>;
   rebalanceEvents: Array<{
@@ -2616,6 +2680,8 @@ export type CoolerLoanEventsQuery = {
     principalPayable: number;
     secondsToExpiry: number;
     transactionHash: string;
+    clearinghouseSDaiBalance: number;
+    clearinghouseSDaiInDaiBalance: number;
     loan: { id: string };
   }>;
 };
@@ -2765,6 +2831,8 @@ export const CoolerLoanEventsDocument = {
                     ],
                   },
                 },
+                { kind: "Field", name: { kind: "Name", value: "clearinghouseSDaiBalance" } },
+                { kind: "Field", name: { kind: "Name", value: "clearinghouseSDaiInDaiBalance" } },
               ],
             },
           },
@@ -2900,6 +2968,8 @@ export const CoolerLoanEventsDocument = {
                     selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
                   },
                 },
+                { kind: "Field", name: { kind: "Name", value: "clearinghouseSDaiBalance" } },
+                { kind: "Field", name: { kind: "Name", value: "clearinghouseSDaiInDaiBalance" } },
               ],
             },
           },
@@ -3037,6 +3107,8 @@ export const CoolerLoanEventsDocument = {
                     selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
                   },
                 },
+                { kind: "Field", name: { kind: "Name", value: "clearinghouseSDaiBalance" } },
+                { kind: "Field", name: { kind: "Name", value: "clearinghouseSDaiInDaiBalance" } },
               ],
             },
           },

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -2586,6 +2586,7 @@ export type CoolerLoanEventsQuery = {
       lender: string;
       loanId: number;
       principal: number;
+      request: { interestPercentage: number; durationSeconds: number };
     };
   }>;
   defundEvents: Array<{
@@ -2828,6 +2829,17 @@ export const CoolerLoanEventsDocument = {
                       { kind: "Field", name: { kind: "Name", value: "lender" } },
                       { kind: "Field", name: { kind: "Name", value: "loanId" } },
                       { kind: "Field", name: { kind: "Name", value: "principal" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "request" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "interestPercentage" } },
+                            { kind: "Field", name: { kind: "Name", value: "durationSeconds" } },
+                          ],
+                        },
+                      },
                     ],
                   },
                 },

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -25,6 +25,10 @@ export type Loan = {
   borrowerAddress: string;
   lenderAddress: string;
   /**
+   * The loan duration, in seconds.
+   */
+  durationSeconds: number;
+  /**
    * The loan principal. Will not change after loan creation.
    */
   principal: number;
@@ -32,6 +36,12 @@ export type Loan = {
    * Cumulative principal paid on the loan.
    */
   principalPaid: number;
+  /**
+   * The interest rate, stored as a decimal.
+   *
+   * e.g. 0.5% = 0.005
+   */
+  interestRate: number;
   /**
    * The total interest charged on the loan.
    *

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -94,6 +94,9 @@ export type Snapshot = {
    * Quantity of collateral deposited across all Coolers
    */
   collateralDeposited: number;
+  /**
+   * Represents the state of the Clearinghouse at the time of the snapshot.
+   */
   clearinghouse: {
     daiBalance: number;
     sDaiBalance: number;
@@ -104,6 +107,9 @@ export type Snapshot = {
     collateralAddress: string;
     debtAddress: string;
   };
+  /**
+   * Represents the state of the Treasury at the time of the snapshot.
+   */
   treasury: {
     daiBalance: number;
     sDaiBalance: number;

--- a/src/types/subgraph.ts
+++ b/src/types/subgraph.ts
@@ -13,7 +13,12 @@ import {
 export type CoolerLoanOptional = Omit<
   CoolerLoan,
   "creationEvents" | "repaymentEvents" | "defaultedClaimEvents" | "extendEvents" | "request"
->;
+> & {
+  request: {
+    interestPercentage: number;
+    durationSeconds: number;
+  };
+};
 export type ClearinghouseSnapshotOptional = Omit<ClearinghouseSnapshot, "rebalanceEvents" | "defundEvents">;
 export type ClearLoanRequestEventOptional = Omit<ClearLoanRequestEvent, "request" | "loan"> & {
   loan: CoolerLoanOptional;


### PR DESCRIPTION
- Avoid GraphQL record limits by chunking fetching and record generation into 7 day periods
- Shift to subgraph v1.3.1
- Correct method for calculating interest on extensions
- Process events by timestamp, so that they are done in order
- Use the clearinghouse balances from events to update the snapshot, instead of manual calculations