### PR TITLE
Improve performance of API

### DIFF
--- a/openapi/snapshot.yaml
+++ b/openapi/snapshot.yaml
@@ -347,6 +347,19 @@
       "creationEvents": { "items": { "$ref": "#/definitions/ClearLoanRequestEventOptional" }, "type": "array" },
       "date": { "format": "date-time", "type": "string" },
       "defaultedClaimEvents": { "items": { "$ref": "#/definitions/ClaimDefaultedLoanEventOptional" }, "type": "array" },
+      "expiryBuckets":
+        {
+          "description": "Principal due for each expiry bucket.",
+          "properties":
+            {
+              "121Days": { "type": "number" },
+              "30Days": { "type": "number" },
+              "active": { "type": "number" },
+              "expired": { "type": "number" },
+            },
+          "required": ["121Days", "30Days", "active", "expired"],
+          "type": "object",
+        },
       "extendEvents": { "items": { "$ref": "#/definitions/ExtendLoanEventOptional" }, "type": "array" },
       "interestIncome": { "description": "Income from interest payments made on this date.", "type": "number" },
       "interestReceivables": { "description": "Interest receivable across all Coolers", "type": "number" },
@@ -424,7 +437,7 @@
                 ],
               "type": "object",
             },
-          "description": "Dictionary of the loans that had been created by this date.\n\nKey: `cooler address`-`loanId`\nValue: Loan record",
+          "description": "Dictionary of the loans that had been created by this date.\n\nKey: `cooler address`-`loanId`\nValue: Loan record\n\nWill only be fetched if explicitly specified.",
           "type": "object",
         },
       "principalReceivables": { "description": "Principal receivable across all Coolers", "type": "number" },
@@ -463,6 +476,7 @@
       "creationEvents",
       "date",
       "defaultedClaimEvents",
+      "expiryBuckets",
       "extendEvents",
       "interestIncome",
       "interestReceivables",

--- a/pulumi.ts
+++ b/pulumi.ts
@@ -54,7 +54,7 @@ const functionGenerate = new gcp.cloudfunctions.HttpCallbackFunction(
   {
     runtime: "nodejs18",
     availableMemoryMb: 512,
-    timeout: 540,
+    timeout: 300, // This ensures that the function ends before the next scheduled run
     callback: handleGenerate,
     environmentVariables: {
       GRAPHQL_ENDPOINT: pulumiConfig.require("GRAPHQL_ENDPOINT"),
@@ -260,7 +260,7 @@ new gcp.monitoring.AlertPolicy(
           filter: pulumi.interpolate`
             resource.type = "cloud_function" AND
             resource.labels.function_name = "${functionGet.function.name}" AND
-            metric.type = "cloudfunctions.googleapis.com/function/execution_count" AND 
+            metric.type = "cloudfunctions.googleapis.com/function/execution_count" AND
             metric.labels.status != "ok"
             `,
           aggregations: [
@@ -303,7 +303,7 @@ new gcp.monitoring.AlertPolicy(
           filter: pulumi.interpolate`
             resource.type = "cloud_function" AND
             resource.labels.function_name = "${functionGenerate.function.name}" AND
-            metric.type = "cloudfunctions.googleapis.com/function/execution_count" AND 
+            metric.type = "cloudfunctions.googleapis.com/function/execution_count" AND
             metric.labels.status != "ok"
             `,
           aggregations: [

--- a/src/functions/generate/__tests__/snapshot.test.ts
+++ b/src/functions/generate/__tests__/snapshot.test.ts
@@ -278,6 +278,17 @@ describe("generateSnapshots", () => {
     expect(resultOne.extendEvents).toHaveLength(0);
     expect(resultOne.clearinghouseEvents).toHaveLength(0);
 
+    expect(resultOne.expiryBuckets.active).toEqual(0);
+    expect(resultOne.expiryBuckets.expired).toEqual(0);
+    expect(resultOne.expiryBuckets["30Days"]).toEqual(0);
+    expect(resultOne.expiryBuckets["121Days"]).toEqual(0);
+    expect(
+      resultOne.expiryBuckets.active +
+      resultOne.expiryBuckets.expired +
+      resultOne.expiryBuckets["30Days"] +
+      resultOne.expiryBuckets["121Days"],
+    ).toEqual(resultOne.principalReceivables);
+
     expect(result.length).toEqual(31);
   });
 
@@ -334,6 +345,17 @@ describe("generateSnapshots", () => {
     expect(snapshotOne.treasury.sDaiBalance).toEqual(TREASURY_SDAI_BALANCE_AFTER_CREATION);
     expect(snapshotOne.treasury.sDaiInDaiBalance).toEqual(TREASURY_SDAI_IN_DAI_BALANCE_AFTER_CREATION);
 
+    expect(snapshotOne.expiryBuckets.active).toEqual(0);
+    expect(snapshotOne.expiryBuckets.expired).toEqual(0);
+    expect(snapshotOne.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotOne.expiryBuckets["121Days"]).toEqual(LOAN_PRINCIPAL);
+    expect(
+      snapshotOne.expiryBuckets.active +
+      snapshotOne.expiryBuckets.expired +
+      snapshotOne.expiryBuckets["30Days"] +
+      snapshotOne.expiryBuckets["121Days"],
+    ).toEqual(snapshotOne.principalReceivables);
+
     const snapshotTwo = snapshots[1];
     expect(snapshotTwo.date.toISOString()).toEqual("2023-08-02T23:59:59.999Z");
     expect(snapshotTwo.principalReceivables).toEqual(LOAN_PRINCIPAL);
@@ -371,6 +393,28 @@ describe("generateSnapshots", () => {
     expect(snapshotTwo.treasury.daiBalance).toEqual(TREASURY_DAI_BALANCE_AFTER_CREATION);
     expect(snapshotTwo.treasury.sDaiBalance).toEqual(TREASURY_SDAI_BALANCE_AFTER_CREATION);
     expect(snapshotTwo.treasury.sDaiInDaiBalance).toEqual(TREASURY_SDAI_IN_DAI_BALANCE_AFTER_CREATION);
+
+    expect(snapshotTwo.expiryBuckets.active).toEqual(0);
+    expect(snapshotTwo.expiryBuckets.expired).toEqual(0);
+    expect(snapshotTwo.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotTwo.expiryBuckets["121Days"]).toEqual(LOAN_PRINCIPAL);
+    expect(
+      snapshotTwo.expiryBuckets.active +
+      snapshotTwo.expiryBuckets.expired +
+      snapshotTwo.expiryBuckets["30Days"] +
+      snapshotTwo.expiryBuckets["121Days"],
+    ).toEqual(snapshotTwo.principalReceivables);
+  });
+
+  it("expiry buckets - 30 days", () => {
+    const startDate = new Date("2023-08-01");
+    const beforeDate = new Date("2023-08-03");
+    const previousDateRecords: Snapshot | null = null;
+    const subgraphData = getSampleData();
+
+    const snapshots = generateSnapshots(startDate, beforeDate, previousDateRecords, subgraphData);
+
+    expect(snapshots.length).toEqual(2);
   });
 
   it("multiple loans", () => {
@@ -459,10 +503,26 @@ describe("generateSnapshots", () => {
     // eslint-disable-next-line prettier/prettier
     expect(snapshotTwo.principalReceivables).toEqual(
       snapshotTwoLoanOne.principal -
-        snapshotTwoLoanOne.principalPaid +
-        snapshotTwoLoanTwo.principal -
-        snapshotTwoLoanTwo.principalPaid,
+      snapshotTwoLoanOne.principalPaid +
+      snapshotTwoLoanTwo.principal -
+      snapshotTwoLoanTwo.principalPaid,
     );
+
+    expect(snapshotTwo.expiryBuckets.active).toEqual(0);
+    expect(snapshotTwo.expiryBuckets.expired).toEqual(0);
+    expect(snapshotTwo.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotTwo.expiryBuckets["121Days"]).toEqual(
+      snapshotTwoLoanOne.principal -
+      snapshotTwoLoanOne.principalPaid +
+      snapshotTwoLoanTwo.principal -
+      snapshotTwoLoanTwo.principalPaid,
+    );
+    expect(
+      snapshotTwo.expiryBuckets.active +
+      snapshotTwo.expiryBuckets.expired +
+      snapshotTwo.expiryBuckets["30Days"] +
+      snapshotTwo.expiryBuckets["121Days"],
+    ).toEqual(snapshotTwo.principalReceivables);
 
     // Skip to day 10 after payment
     const snapshotTen = snapshots[9];
@@ -481,10 +541,25 @@ describe("generateSnapshots", () => {
     // eslint-disable-next-line prettier/prettier
     expect(snapshotTen.principalReceivables).toEqual(
       snapshotTenLoanOne.principal -
-        snapshotTenLoanOne.principalPaid +
-        snapshotTenLoanTwo.principal +
-        snapshotTenLoanTwo.principalPaid,
+      snapshotTenLoanOne.principalPaid +
+      snapshotTenLoanTwo.principal +
+      snapshotTenLoanTwo.principalPaid,
     );
+
+    expect(snapshotTen.expiryBuckets.active).toEqual(0);
+    expect(snapshotTen.expiryBuckets.expired).toEqual(0);
+    expect(snapshotTen.expiryBuckets["30Days"]).toEqual(
+      snapshotTenLoanTwo.principal + snapshotTenLoanTwo.principalPaid,
+    );
+    expect(snapshotTen.expiryBuckets["121Days"]).toEqual(
+      snapshotTenLoanOne.principal - snapshotTenLoanOne.principalPaid,
+    );
+    expect(
+      snapshotTen.expiryBuckets.active +
+      snapshotTen.expiryBuckets.expired +
+      snapshotTen.expiryBuckets["30Days"] +
+      snapshotTen.expiryBuckets["121Days"],
+    ).toEqual(snapshotTen.principalReceivables);
   });
 
   it("loan repayment < interest due", () => {
@@ -541,6 +616,17 @@ describe("generateSnapshots", () => {
     expect(snapshotTen.treasury.sDaiBalance).toEqual(TREASURY_SDAI_BALANCE_AFTER_REPAYMENT);
     expect(snapshotTen.treasury.sDaiInDaiBalance).toEqual(TREASURY_SDAI_IN_DAI_BALANCE_AFTER_REPAYMENT);
 
+    expect(snapshotTen.expiryBuckets.active).toEqual(0);
+    expect(snapshotTen.expiryBuckets.expired).toEqual(0);
+    expect(snapshotTen.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotTen.expiryBuckets["121Days"]).toEqual(LOAN_PRINCIPAL);
+    expect(
+      snapshotTen.expiryBuckets.active +
+      snapshotTen.expiryBuckets.expired +
+      snapshotTen.expiryBuckets["30Days"] +
+      snapshotTen.expiryBuckets["121Days"],
+    ).toEqual(snapshotTen.principalReceivables);
+
     // Day after should be the same
     const snapshotEleven = snapshots[10];
     expect(snapshotEleven.date.toISOString()).toEqual("2023-08-11T23:59:59.999Z");
@@ -585,6 +671,17 @@ describe("generateSnapshots", () => {
     expect(snapshotEleven.treasury.daiBalance).toEqual(TREASURY_DAI_BALANCE_AFTER_REPAYMENT);
     expect(snapshotEleven.treasury.sDaiBalance).toEqual(TREASURY_SDAI_BALANCE_AFTER_REPAYMENT);
     expect(snapshotEleven.treasury.sDaiInDaiBalance).toEqual(TREASURY_SDAI_IN_DAI_BALANCE_AFTER_REPAYMENT);
+
+    expect(snapshotEleven.expiryBuckets.active).toEqual(0);
+    expect(snapshotEleven.expiryBuckets.expired).toEqual(0);
+    expect(snapshotEleven.expiryBuckets["30Days"]).toEqual(LOAN_PRINCIPAL);
+    expect(snapshotEleven.expiryBuckets["121Days"]).toEqual(0);
+    expect(
+      snapshotEleven.expiryBuckets.active +
+      snapshotEleven.expiryBuckets.expired +
+      snapshotEleven.expiryBuckets["30Days"] +
+      snapshotEleven.expiryBuckets["121Days"],
+    ).toEqual(snapshotEleven.principalReceivables);
   });
 
   it("loan full repayment", () => {
@@ -672,6 +769,17 @@ describe("generateSnapshots", () => {
     expect(snapshotTwelve.treasury.daiBalance).toEqual(treasuryDaiBalance);
     expect(snapshotTwelve.treasury.sDaiBalance).toEqual(treasurySDaiBalance);
     expect(snapshotTwelve.treasury.sDaiInDaiBalance).toEqual(treasurySDaiInDaiBalance);
+
+    expect(snapshotTwelve.expiryBuckets.active).toEqual(0);
+    expect(snapshotTwelve.expiryBuckets.expired).toEqual(0);
+    expect(snapshotTwelve.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotTwelve.expiryBuckets["121Days"]).toEqual(0);
+    expect(
+      snapshotTwelve.expiryBuckets.active +
+      snapshotTwelve.expiryBuckets.expired +
+      snapshotTwelve.expiryBuckets["30Days"] +
+      snapshotTwelve.expiryBuckets["121Days"],
+    ).toEqual(snapshotTwelve.principalReceivables);
   });
 
   it("clearinghouse balances", () => {
@@ -900,6 +1008,12 @@ describe("generateSnapshots", () => {
           interestRate: CLEARINGHOUSE_INTEREST_RATE,
         },
       },
+      expiryBuckets: {
+        active: 0,
+        expired: 0,
+        "30Days": 0,
+        "121Days": 0,
+      },
       creationEvents: [],
       defaultedClaimEvents: [],
       repaymentEvents: [],
@@ -1008,6 +1122,17 @@ describe("generateSnapshots", () => {
     expect(snapshotDayOfExpiry.extendEvents.length).toEqual(0);
     expect(snapshotDayOfExpiry.clearinghouseEvents.length).toEqual(0);
 
+    expect(snapshotDayOfExpiry.expiryBuckets.active).toEqual(0);
+    expect(snapshotDayOfExpiry.expiryBuckets.expired).toEqual(LOAN_PRINCIPAL);
+    expect(snapshotDayOfExpiry.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotDayOfExpiry.expiryBuckets["121Days"]).toEqual(0);
+    expect(
+      snapshotDayOfExpiry.expiryBuckets.active +
+      snapshotDayOfExpiry.expiryBuckets.expired +
+      snapshotDayOfExpiry.expiryBuckets["30Days"] +
+      snapshotDayOfExpiry.expiryBuckets["121Days"],
+    ).toEqual(snapshotDayOfExpiry.principalReceivables);
+
     // Same for the next day
     const snapshotDayAfterExpiry = snapshots[41];
     expect(snapshotDayAfterExpiry.date.toISOString()).toEqual("2023-09-11T23:59:59.999Z");
@@ -1034,6 +1159,17 @@ describe("generateSnapshots", () => {
     expect(snapshotDayAfterExpiry.defaultedClaimEvents.length).toEqual(0);
     expect(snapshotDayAfterExpiry.extendEvents.length).toEqual(0);
     expect(snapshotDayAfterExpiry.clearinghouseEvents.length).toEqual(0);
+
+    expect(snapshotDayAfterExpiry.expiryBuckets.active).toEqual(0);
+    expect(snapshotDayAfterExpiry.expiryBuckets.expired).toEqual(LOAN_PRINCIPAL);
+    expect(snapshotDayAfterExpiry.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotDayAfterExpiry.expiryBuckets["121Days"]).toEqual(0);
+    expect(
+      snapshotDayAfterExpiry.expiryBuckets.active +
+      snapshotDayAfterExpiry.expiryBuckets.expired +
+      snapshotDayAfterExpiry.expiryBuckets["30Days"] +
+      snapshotDayAfterExpiry.expiryBuckets["121Days"],
+    ).toEqual(snapshotDayAfterExpiry.principalReceivables);
   });
 
   it("loan default claim", () => {
@@ -1080,6 +1216,17 @@ describe("generateSnapshots", () => {
     expect(snapshotDayOfExpiry.extendEvents.length).toEqual(0);
     expect(snapshotDayOfExpiry.clearinghouseEvents.length).toEqual(0);
 
+    expect(snapshotDayOfExpiry.expiryBuckets.active).toEqual(0);
+    expect(snapshotDayOfExpiry.expiryBuckets.expired).toEqual(0);
+    expect(snapshotDayOfExpiry.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotDayOfExpiry.expiryBuckets["121Days"]).toEqual(0);
+    expect(
+      snapshotDayOfExpiry.expiryBuckets.active +
+      snapshotDayOfExpiry.expiryBuckets.expired +
+      snapshotDayOfExpiry.expiryBuckets["30Days"] +
+      snapshotDayOfExpiry.expiryBuckets["121Days"],
+    ).toEqual(snapshotDayOfExpiry.principalReceivables);
+
     // Same for next day
     const snapshotDayAfterExpiry = snapshots[43];
     expect(snapshotDayAfterExpiry.date.toISOString()).toEqual("2023-09-13T23:59:59.999Z");
@@ -1108,6 +1255,17 @@ describe("generateSnapshots", () => {
     expect(snapshotDayAfterExpiry.defaultedClaimEvents.length).toEqual(0);
     expect(snapshotDayAfterExpiry.extendEvents.length).toEqual(0);
     expect(snapshotDayAfterExpiry.clearinghouseEvents.length).toEqual(0);
+
+    expect(snapshotDayAfterExpiry.expiryBuckets.active).toEqual(0);
+    expect(snapshotDayAfterExpiry.expiryBuckets.expired).toEqual(0);
+    expect(snapshotDayAfterExpiry.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotDayAfterExpiry.expiryBuckets["121Days"]).toEqual(0);
+    expect(
+      snapshotDayAfterExpiry.expiryBuckets.active +
+      snapshotDayAfterExpiry.expiryBuckets.expired +
+      snapshotDayAfterExpiry.expiryBuckets["30Days"] +
+      snapshotDayAfterExpiry.expiryBuckets["121Days"],
+    ).toEqual(snapshotDayAfterExpiry.principalReceivables);
   });
 
   it("loan default claim, multiple", () => {
@@ -1354,6 +1512,17 @@ describe("generateSnapshots", () => {
     expect(snapshotTwelve.defaultedClaimEvents.length).toEqual(0);
     expect(snapshotTwelve.extendEvents.length).toEqual(1);
     expect(snapshotTwelve.clearinghouseEvents.length).toEqual(0);
+
+    expect(snapshotTwelve.expiryBuckets.active).toEqual(LOAN_PRINCIPAL);
+    expect(snapshotTwelve.expiryBuckets.expired).toEqual(0);
+    expect(snapshotTwelve.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotTwelve.expiryBuckets["121Days"]).toEqual(0);
+    expect(
+      snapshotTwelve.expiryBuckets.active +
+      snapshotTwelve.expiryBuckets.expired +
+      snapshotTwelve.expiryBuckets["30Days"] +
+      snapshotTwelve.expiryBuckets["121Days"],
+    ).toEqual(snapshotTwelve.principalReceivables);
   });
 
   it("loan repayment, extension, then repayment", () => {
@@ -1367,7 +1536,7 @@ describe("generateSnapshots", () => {
     // Add extension on day 12
     const extensionOnePeriods = 2;
     const extensionOneAdditionalInterest = extensionOnePeriods * getInterestForLoan(LOAN_PRINCIPAL);
-    const extensionOneExpiryTimestamp = 1699999000;
+    const extensionOneExpiryTimestamp = 1699999000; // 2023-11-14
     const extensionOneClearinghouseDaiBalance = 200;
     const extensionOneClearinghouseSDaiBalance = 200.1;
     const extensionOneClearinghouseSDaiInDaiBalance = 200.2;
@@ -1466,6 +1635,17 @@ describe("generateSnapshots", () => {
     expect(snapshotThirteen.defaultedClaimEvents.length).toEqual(0);
     expect(snapshotThirteen.extendEvents.length).toEqual(0);
     expect(snapshotThirteen.clearinghouseEvents.length).toEqual(0);
+
+    expect(snapshotThirteen.expiryBuckets.active).toEqual(0);
+    expect(snapshotThirteen.expiryBuckets.expired).toEqual(0);
+    expect(snapshotThirteen.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotThirteen.expiryBuckets["121Days"]).toEqual(repaymentTwoPrincipalDueAfter);
+    expect(
+      snapshotThirteen.expiryBuckets.active +
+      snapshotThirteen.expiryBuckets.expired +
+      snapshotThirteen.expiryBuckets["30Days"] +
+      snapshotThirteen.expiryBuckets["121Days"],
+    ).toEqual(snapshotThirteen.principalReceivables);
   });
 
   it("loan repayment then extension x2", () => {
@@ -1612,6 +1792,17 @@ describe("generateSnapshots", () => {
     expect(snapshotFourteen.defaultedClaimEvents.length).toEqual(0);
     expect(snapshotFourteen.extendEvents.length).toEqual(1);
     expect(snapshotFourteen.clearinghouseEvents.length).toEqual(0);
+
+    expect(snapshotFourteen.expiryBuckets.active).toEqual(0);
+    expect(snapshotFourteen.expiryBuckets.expired).toEqual(0);
+    expect(snapshotFourteen.expiryBuckets["30Days"]).toEqual(0);
+    expect(snapshotFourteen.expiryBuckets["121Days"]).toEqual(repaymentTwoPrincipalDueAfter);
+    expect(
+      snapshotFourteen.expiryBuckets.active +
+      snapshotFourteen.expiryBuckets.expired +
+      snapshotFourteen.expiryBuckets["30Days"] +
+      snapshotFourteen.expiryBuckets["121Days"],
+    ).toEqual(snapshotFourteen.principalReceivables);
   });
 
   it("loan extension then repayment, same day", () => {

--- a/src/functions/generate/__tests__/snapshot.test.ts
+++ b/src/functions/generate/__tests__/snapshot.test.ts
@@ -284,9 +284,9 @@ describe("generateSnapshots", () => {
     expect(resultOne.expiryBuckets["121Days"]).toEqual(0);
     expect(
       resultOne.expiryBuckets.active +
-      resultOne.expiryBuckets.expired +
-      resultOne.expiryBuckets["30Days"] +
-      resultOne.expiryBuckets["121Days"],
+        resultOne.expiryBuckets.expired +
+        resultOne.expiryBuckets["30Days"] +
+        resultOne.expiryBuckets["121Days"],
     ).toEqual(resultOne.principalReceivables);
 
     expect(result.length).toEqual(31);
@@ -351,9 +351,9 @@ describe("generateSnapshots", () => {
     expect(snapshotOne.expiryBuckets["121Days"]).toEqual(LOAN_PRINCIPAL);
     expect(
       snapshotOne.expiryBuckets.active +
-      snapshotOne.expiryBuckets.expired +
-      snapshotOne.expiryBuckets["30Days"] +
-      snapshotOne.expiryBuckets["121Days"],
+        snapshotOne.expiryBuckets.expired +
+        snapshotOne.expiryBuckets["30Days"] +
+        snapshotOne.expiryBuckets["121Days"],
     ).toEqual(snapshotOne.principalReceivables);
 
     const snapshotTwo = snapshots[1];
@@ -400,9 +400,9 @@ describe("generateSnapshots", () => {
     expect(snapshotTwo.expiryBuckets["121Days"]).toEqual(LOAN_PRINCIPAL);
     expect(
       snapshotTwo.expiryBuckets.active +
-      snapshotTwo.expiryBuckets.expired +
-      snapshotTwo.expiryBuckets["30Days"] +
-      snapshotTwo.expiryBuckets["121Days"],
+        snapshotTwo.expiryBuckets.expired +
+        snapshotTwo.expiryBuckets["30Days"] +
+        snapshotTwo.expiryBuckets["121Days"],
     ).toEqual(snapshotTwo.principalReceivables);
   });
 
@@ -503,9 +503,9 @@ describe("generateSnapshots", () => {
     // eslint-disable-next-line prettier/prettier
     expect(snapshotTwo.principalReceivables).toEqual(
       snapshotTwoLoanOne.principal -
-      snapshotTwoLoanOne.principalPaid +
-      snapshotTwoLoanTwo.principal -
-      snapshotTwoLoanTwo.principalPaid,
+        snapshotTwoLoanOne.principalPaid +
+        snapshotTwoLoanTwo.principal -
+        snapshotTwoLoanTwo.principalPaid,
     );
 
     expect(snapshotTwo.expiryBuckets.active).toEqual(0);
@@ -513,15 +513,15 @@ describe("generateSnapshots", () => {
     expect(snapshotTwo.expiryBuckets["30Days"]).toEqual(0);
     expect(snapshotTwo.expiryBuckets["121Days"]).toEqual(
       snapshotTwoLoanOne.principal -
-      snapshotTwoLoanOne.principalPaid +
-      snapshotTwoLoanTwo.principal -
-      snapshotTwoLoanTwo.principalPaid,
+        snapshotTwoLoanOne.principalPaid +
+        snapshotTwoLoanTwo.principal -
+        snapshotTwoLoanTwo.principalPaid,
     );
     expect(
       snapshotTwo.expiryBuckets.active +
-      snapshotTwo.expiryBuckets.expired +
-      snapshotTwo.expiryBuckets["30Days"] +
-      snapshotTwo.expiryBuckets["121Days"],
+        snapshotTwo.expiryBuckets.expired +
+        snapshotTwo.expiryBuckets["30Days"] +
+        snapshotTwo.expiryBuckets["121Days"],
     ).toEqual(snapshotTwo.principalReceivables);
 
     // Skip to day 10 after payment
@@ -541,9 +541,9 @@ describe("generateSnapshots", () => {
     // eslint-disable-next-line prettier/prettier
     expect(snapshotTen.principalReceivables).toEqual(
       snapshotTenLoanOne.principal -
-      snapshotTenLoanOne.principalPaid +
-      snapshotTenLoanTwo.principal +
-      snapshotTenLoanTwo.principalPaid,
+        snapshotTenLoanOne.principalPaid +
+        snapshotTenLoanTwo.principal +
+        snapshotTenLoanTwo.principalPaid,
     );
 
     expect(snapshotTen.expiryBuckets.active).toEqual(0);
@@ -556,9 +556,9 @@ describe("generateSnapshots", () => {
     );
     expect(
       snapshotTen.expiryBuckets.active +
-      snapshotTen.expiryBuckets.expired +
-      snapshotTen.expiryBuckets["30Days"] +
-      snapshotTen.expiryBuckets["121Days"],
+        snapshotTen.expiryBuckets.expired +
+        snapshotTen.expiryBuckets["30Days"] +
+        snapshotTen.expiryBuckets["121Days"],
     ).toEqual(snapshotTen.principalReceivables);
   });
 
@@ -622,9 +622,9 @@ describe("generateSnapshots", () => {
     expect(snapshotTen.expiryBuckets["121Days"]).toEqual(LOAN_PRINCIPAL);
     expect(
       snapshotTen.expiryBuckets.active +
-      snapshotTen.expiryBuckets.expired +
-      snapshotTen.expiryBuckets["30Days"] +
-      snapshotTen.expiryBuckets["121Days"],
+        snapshotTen.expiryBuckets.expired +
+        snapshotTen.expiryBuckets["30Days"] +
+        snapshotTen.expiryBuckets["121Days"],
     ).toEqual(snapshotTen.principalReceivables);
 
     // Day after should be the same
@@ -678,9 +678,9 @@ describe("generateSnapshots", () => {
     expect(snapshotEleven.expiryBuckets["121Days"]).toEqual(0);
     expect(
       snapshotEleven.expiryBuckets.active +
-      snapshotEleven.expiryBuckets.expired +
-      snapshotEleven.expiryBuckets["30Days"] +
-      snapshotEleven.expiryBuckets["121Days"],
+        snapshotEleven.expiryBuckets.expired +
+        snapshotEleven.expiryBuckets["30Days"] +
+        snapshotEleven.expiryBuckets["121Days"],
     ).toEqual(snapshotEleven.principalReceivables);
   });
 
@@ -776,9 +776,9 @@ describe("generateSnapshots", () => {
     expect(snapshotTwelve.expiryBuckets["121Days"]).toEqual(0);
     expect(
       snapshotTwelve.expiryBuckets.active +
-      snapshotTwelve.expiryBuckets.expired +
-      snapshotTwelve.expiryBuckets["30Days"] +
-      snapshotTwelve.expiryBuckets["121Days"],
+        snapshotTwelve.expiryBuckets.expired +
+        snapshotTwelve.expiryBuckets["30Days"] +
+        snapshotTwelve.expiryBuckets["121Days"],
     ).toEqual(snapshotTwelve.principalReceivables);
   });
 
@@ -1128,9 +1128,9 @@ describe("generateSnapshots", () => {
     expect(snapshotDayOfExpiry.expiryBuckets["121Days"]).toEqual(0);
     expect(
       snapshotDayOfExpiry.expiryBuckets.active +
-      snapshotDayOfExpiry.expiryBuckets.expired +
-      snapshotDayOfExpiry.expiryBuckets["30Days"] +
-      snapshotDayOfExpiry.expiryBuckets["121Days"],
+        snapshotDayOfExpiry.expiryBuckets.expired +
+        snapshotDayOfExpiry.expiryBuckets["30Days"] +
+        snapshotDayOfExpiry.expiryBuckets["121Days"],
     ).toEqual(snapshotDayOfExpiry.principalReceivables);
 
     // Same for the next day
@@ -1166,9 +1166,9 @@ describe("generateSnapshots", () => {
     expect(snapshotDayAfterExpiry.expiryBuckets["121Days"]).toEqual(0);
     expect(
       snapshotDayAfterExpiry.expiryBuckets.active +
-      snapshotDayAfterExpiry.expiryBuckets.expired +
-      snapshotDayAfterExpiry.expiryBuckets["30Days"] +
-      snapshotDayAfterExpiry.expiryBuckets["121Days"],
+        snapshotDayAfterExpiry.expiryBuckets.expired +
+        snapshotDayAfterExpiry.expiryBuckets["30Days"] +
+        snapshotDayAfterExpiry.expiryBuckets["121Days"],
     ).toEqual(snapshotDayAfterExpiry.principalReceivables);
   });
 
@@ -1222,9 +1222,9 @@ describe("generateSnapshots", () => {
     expect(snapshotDayOfExpiry.expiryBuckets["121Days"]).toEqual(0);
     expect(
       snapshotDayOfExpiry.expiryBuckets.active +
-      snapshotDayOfExpiry.expiryBuckets.expired +
-      snapshotDayOfExpiry.expiryBuckets["30Days"] +
-      snapshotDayOfExpiry.expiryBuckets["121Days"],
+        snapshotDayOfExpiry.expiryBuckets.expired +
+        snapshotDayOfExpiry.expiryBuckets["30Days"] +
+        snapshotDayOfExpiry.expiryBuckets["121Days"],
     ).toEqual(snapshotDayOfExpiry.principalReceivables);
 
     // Same for next day
@@ -1262,9 +1262,9 @@ describe("generateSnapshots", () => {
     expect(snapshotDayAfterExpiry.expiryBuckets["121Days"]).toEqual(0);
     expect(
       snapshotDayAfterExpiry.expiryBuckets.active +
-      snapshotDayAfterExpiry.expiryBuckets.expired +
-      snapshotDayAfterExpiry.expiryBuckets["30Days"] +
-      snapshotDayAfterExpiry.expiryBuckets["121Days"],
+        snapshotDayAfterExpiry.expiryBuckets.expired +
+        snapshotDayAfterExpiry.expiryBuckets["30Days"] +
+        snapshotDayAfterExpiry.expiryBuckets["121Days"],
     ).toEqual(snapshotDayAfterExpiry.principalReceivables);
   });
 
@@ -1519,9 +1519,9 @@ describe("generateSnapshots", () => {
     expect(snapshotTwelve.expiryBuckets["121Days"]).toEqual(0);
     expect(
       snapshotTwelve.expiryBuckets.active +
-      snapshotTwelve.expiryBuckets.expired +
-      snapshotTwelve.expiryBuckets["30Days"] +
-      snapshotTwelve.expiryBuckets["121Days"],
+        snapshotTwelve.expiryBuckets.expired +
+        snapshotTwelve.expiryBuckets["30Days"] +
+        snapshotTwelve.expiryBuckets["121Days"],
     ).toEqual(snapshotTwelve.principalReceivables);
   });
 
@@ -1642,9 +1642,9 @@ describe("generateSnapshots", () => {
     expect(snapshotThirteen.expiryBuckets["121Days"]).toEqual(repaymentTwoPrincipalDueAfter);
     expect(
       snapshotThirteen.expiryBuckets.active +
-      snapshotThirteen.expiryBuckets.expired +
-      snapshotThirteen.expiryBuckets["30Days"] +
-      snapshotThirteen.expiryBuckets["121Days"],
+        snapshotThirteen.expiryBuckets.expired +
+        snapshotThirteen.expiryBuckets["30Days"] +
+        snapshotThirteen.expiryBuckets["121Days"],
     ).toEqual(snapshotThirteen.principalReceivables);
   });
 
@@ -1799,9 +1799,9 @@ describe("generateSnapshots", () => {
     expect(snapshotFourteen.expiryBuckets["121Days"]).toEqual(repaymentTwoPrincipalDueAfter);
     expect(
       snapshotFourteen.expiryBuckets.active +
-      snapshotFourteen.expiryBuckets.expired +
-      snapshotFourteen.expiryBuckets["30Days"] +
-      snapshotFourteen.expiryBuckets["121Days"],
+        snapshotFourteen.expiryBuckets.expired +
+        snapshotFourteen.expiryBuckets["30Days"] +
+        snapshotFourteen.expiryBuckets["121Days"],
     ).toEqual(snapshotFourteen.principalReceivables);
   });
 

--- a/src/functions/generate/__tests__/storage.test.ts
+++ b/src/functions/generate/__tests__/storage.test.ts
@@ -127,6 +127,12 @@ describe("writeSnapshots", () => {
         loans: {
           "0x3-1": getSampleLoan("0x3-1"),
         },
+        expiryBuckets: {
+          active: 0,
+          expired: 100000,
+          "30Days": 50000,
+          "121Days": 60000,
+        },
         creationEvents: [],
         defaultedClaimEvents: [],
         repaymentEvents: [],
@@ -162,6 +168,12 @@ describe("writeSnapshots", () => {
           loanToCollateral: 0,
         },
         loans: {},
+        expiryBuckets: {
+          active: 1,
+          expired: 100001,
+          "30Days": 50001,
+          "121Days": 60001,
+        },
         creationEvents: [],
         defaultedClaimEvents: [],
         repaymentEvents: [],
@@ -190,13 +202,23 @@ describe("writeSnapshots", () => {
     const snapshotOneLoanOne = snapshotOne?.loans["0x3-1"];
     expect(snapshotOneLoanOne?.principal).toEqual(100);
 
+    expect(snapshotOne?.expiryBuckets.active).toEqual(0);
+    expect(snapshotOne?.expiryBuckets.expired).toEqual(100000);
+    expect(snapshotOne?.expiryBuckets["30Days"]).toEqual(50000);
+    expect(snapshotOne?.expiryBuckets["121Days"]).toEqual(60000);
+
     // Test getSnapshots
-    const snapshotResults = await getSnapshots(new Date("2020-01-01"), new Date("2020-01-03"));
+    const snapshotResults = await getSnapshots(new Date("2020-01-01"), new Date("2020-01-03"), true);
     expect(snapshotResults.length).toEqual(2);
 
     const snapshotResultsOne = snapshotResults[0];
     expect(snapshotResultsOne.date).toEqual(new Date("2020-01-01"));
     expect(snapshotResultsOne.clearinghouse.daiBalance).toEqual(0);
+
+    expect(snapshotResultsOne?.expiryBuckets.active).toEqual(0);
+    expect(snapshotResultsOne?.expiryBuckets.expired).toEqual(100000);
+    expect(snapshotResultsOne?.expiryBuckets["30Days"]).toEqual(50000);
+    expect(snapshotResultsOne?.expiryBuckets["121Days"]).toEqual(60000);
 
     const snapshotResultsTwo = snapshotResults[1];
     expect(snapshotResultsTwo.date).toEqual(new Date("2020-01-02"));
@@ -204,5 +226,10 @@ describe("writeSnapshots", () => {
 
     const snapshotResultsOneLoanOne = snapshotResultsOne.loans["0x3-1"];
     expect(snapshotResultsOneLoanOne?.principal).toEqual(100);
+
+    // Test getSnapshots without loans
+    const snapshotResultsWithoutLoans = await getSnapshots(new Date("2020-01-01"), new Date("2020-01-03"), false);
+    expect(snapshotResultsWithoutLoans[0].loans.length).toEqual(0);
+    expect(snapshotResultsWithoutLoans[1].loans.length).toEqual(0);
   }, 10000);
 });

--- a/src/functions/generate/snapshot.ts
+++ b/src/functions/generate/snapshot.ts
@@ -451,7 +451,8 @@ export const generateSnapshots = (
         const interestPerPeriod =
           ((loan.principal - loan.principalPaid) * loan.interestRate * loan.durationSeconds) / (365 * 24 * 60 * 60);
         console.log(
-          `${FUNC}: interestPerPeriod for loan ${loan.id} on remaining principal ${loan.principal - loan.principalPaid
+          `${FUNC}: interestPerPeriod for loan ${loan.id} on remaining principal ${
+            loan.principal - loan.principalPaid
           }: ${interestPerPeriod}`,
         );
         const newInterest = parseNumber(extendEvent.periods) * interestPerPeriod;

--- a/src/functions/get/index.ts
+++ b/src/functions/get/index.ts
@@ -15,7 +15,7 @@ export async function handleGet(req: any, res: any) {
 
   // Grab from Firestore
   console.log(`Getting snapshots between ${startDate} and ${beforeDate}`);
-  const snapshots = await getSnapshots(new Date(startDate), new Date(beforeDate));
+  const snapshots = await getSnapshots(new Date(startDate), new Date(beforeDate), false);
 
   // Enable caching
   // Source: https://firebase.google.com/docs/hosting/manage-cache

--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -139,6 +139,7 @@ export const getSnapshots = async (startDate: Date, beforeDate: Date): Promise<S
     const snapshot = snapshotRecords[i];
 
     // Get the loans
+    // TODO improve performance here
     const loans = await client
       .collection(FIRESTORE_ROOT_COLLECTION)
       .doc(getISO8601DateString(snapshot.date))

--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -197,8 +197,6 @@ export const writeSnapshots = async (snapshots: Snapshot[]) => {
     // Delete the loans from the snapshot
     snapshot.loans = {};
 
-    console.log(`typeof snapshot.date: ${typeof snapshot.date}`);
-
     // Write the snapshot
     await client
       .collection(FIRESTORE_ROOT_COLLECTION)

--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -1,13 +1,38 @@
 import { DocumentData, Firestore, QueryDocumentSnapshot, Timestamp } from "@google-cloud/firestore";
 
-import { Snapshot } from "../types/snapshot";
+import { Loan, Snapshot, SnapshotLoanMap } from "../types/snapshot";
 import { getISO8601DateString } from "./dateHelper";
 
 const FIRESTORE_ROOT_COLLECTION = "snapshots";
+const FIRESTORE_LOAN_COLLECTION = "loans";
 
 const getClient = () => {
   return new Firestore();
 };
+
+function deepCopy<T>(obj: T): T {
+  if (obj === null || typeof obj !== "object") {
+    return obj;
+  }
+
+  if (obj instanceof Date) {
+    return new Date((obj as Date).getTime()) as unknown as T;
+  }
+
+  if (Array.isArray(obj)) {
+    return (obj as Array<unknown>).map(deepCopy) as unknown as T;
+  }
+
+  const copy: Record<string, unknown> = {};
+
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      copy[key] = deepCopy((obj as Record<string, unknown>)[key]);
+    }
+  }
+
+  return copy as T;
+}
 
 const SnapshotConverter = {
   toFirestore(snapshot: Snapshot): DocumentData {
@@ -22,6 +47,16 @@ const SnapshotConverter = {
       ...data,
       date: data.date.toDate(),
     } as Snapshot;
+  },
+};
+
+const LoanConverter = {
+  toFirestore(loan: Loan): DocumentData {
+    return loan;
+  },
+  fromFirestore(loan: QueryDocumentSnapshot): Loan {
+    const data = loan.data();
+    return data as Loan;
   },
 };
 
@@ -61,6 +96,25 @@ export const getSnapshot = async (date: Date): Promise<Snapshot | null> => {
     return null;
   }
 
+  // Get the loans
+  const loans = await client
+    .collection(FIRESTORE_ROOT_COLLECTION)
+    .doc(getISO8601DateString(date))
+    .collection(FIRESTORE_LOAN_COLLECTION)
+    .withConverter(LoanConverter)
+    .get();
+  let loanMap: SnapshotLoanMap = {};
+  if (!loans.empty) {
+    loanMap = loans.docs.reduce((accumulator, currentValue) => {
+      const loan = currentValue.data();
+      accumulator[loan.id] = loan;
+      return accumulator;
+    }, {} as SnapshotLoanMap);
+  }
+
+  // Add the loans into the snapshot
+  snapshotData.loans = loanMap;
+
   // Return the snapshot
   return snapshotData;
 };
@@ -78,7 +132,51 @@ export const getSnapshots = async (startDate: Date, beforeDate: Date): Promise<S
     .get();
 
   // If there is no snapshot, return null
-  return snapshots.docs.map(snapshot => snapshot.data());
+  const snapshotRecords = snapshots.docs.map(snapshot => snapshot.data());
+
+  // Iterate over the snapshots
+  for (let i = 0; i < snapshotRecords.length; i++) {
+    const snapshot = snapshotRecords[i];
+
+    // Get the loans
+    const loans = await client
+      .collection(FIRESTORE_ROOT_COLLECTION)
+      .doc(getISO8601DateString(snapshot.date))
+      .collection(FIRESTORE_LOAN_COLLECTION)
+      .withConverter(LoanConverter)
+      .get();
+    let loanMap: SnapshotLoanMap = {};
+    if (!loans.empty) {
+      loanMap = loans.docs.reduce((accumulator, currentValue) => {
+        const loan = currentValue.data();
+        accumulator[loan.id] = loan;
+        return accumulator;
+      }, {} as SnapshotLoanMap);
+    }
+
+    // Add the loans into the snapshot
+    snapshot.loans = loanMap;
+  }
+
+  return snapshotRecords;
+};
+
+const writeLoans = async (snapshotDate: Date, loans: Loan[]) => {
+  // Get the Firestore client
+  const client = getClient();
+
+  // Write the loans
+  for (let i = 0; i < loans.length; i++) {
+    const loan = loans[i];
+
+    await client
+      .collection(FIRESTORE_ROOT_COLLECTION)
+      .doc(getISO8601DateString(snapshotDate))
+      .collection(FIRESTORE_LOAN_COLLECTION)
+      .withConverter(LoanConverter)
+      .doc(loan.id)
+      .set(loan);
+  }
 };
 
 export const writeSnapshots = async (snapshots: Snapshot[]) => {
@@ -88,12 +186,28 @@ export const writeSnapshots = async (snapshots: Snapshot[]) => {
 
   // Write the snapshots
   for (let i = 0; i < snapshots.length; i++) {
-    const snapshot = snapshots[i];
+    const currentSnapshot = snapshots[i];
+
+    // Do a deep copy of the snapshot, as it will be modified
+    const snapshot = deepCopy(currentSnapshot) as Snapshot;
+
+    // Extract the loans
+    const loans: Loan[] = Object.values(snapshot.loans);
+
+    // Delete the loans from the snapshot
+    snapshot.loans = {};
+
+    console.log(`typeof snapshot.date: ${typeof snapshot.date}`);
+
+    // Write the snapshot
     await client
       .collection(FIRESTORE_ROOT_COLLECTION)
       .withConverter(SnapshotConverter)
       .doc(getISO8601DateString(snapshot.date))
       .set(snapshot);
+
+    // Write the loans in a sub-collection in order to avoid hitting document limits
+    await writeLoans(snapshot.date, loans);
   }
   console.log("Finished writing snapshots");
 };

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -74,7 +74,7 @@ export type Loan = {
   collateralClaimedValue: number;
 };
 
-type SnapshotLoanMap = {
+export type SnapshotLoanMap = {
   [key: string]: Loan;
 };
 

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -136,7 +136,7 @@ export type Snapshot = {
    * Key: `cooler address`-`loanId`
    * Value: Loan record
    *
-   * @deprecated Will return an empty map
+   * Will only be fetched if explicitly specified.
    */
   loans: SnapshotLoanMap;
 

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -135,8 +135,21 @@ export type Snapshot = {
    *
    * Key: `cooler address`-`loanId`
    * Value: Loan record
+   *
+   * @deprecated Will return an empty map
    */
   loans: SnapshotLoanMap;
+
+  /**
+   * Principal due for each expiry bucket.
+   */
+  expiryBuckets: {
+    active: number;
+    expired: number;
+    "30Days": number;
+    "121Days": number;
+  };
+
   creationEvents: ClearLoanRequestEventOptional[];
   defaultedClaimEvents: ClaimDefaultedLoanEventOptional[];
   repaymentEvents: RepayLoanEventOptional[];


### PR DESCRIPTION
- Fixes an issue with the number of loan records hitting Firestore limits
- Calculates the expiry buckets for each daily snapshot
- Excludes loan records from the getter API (which greatly improves performance)